### PR TITLE
Add links to badges in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,20 @@
 
 <!-- primary badges -->
 <p align="center">
-  <img src="https://img.shields.io/github/workflow/status/seanjameshan/starknet.js/Node.js%20CI/main">
-  <img src='https://img.shields.io/github/package-json/v/seanjameshan/starknet.js?label=npm' />
+  <a href="https://github.com/seanjameshan/starknet.js/actions">
+    <img src="https://img.shields.io/github/workflow/status/seanjameshan/starknet.js/Node.js%20CI/main">
+  </a>
+  <a href="https://www.npmjs.com/package/starknet">
+    <img src='https://img.shields.io/github/package-json/v/seanjameshan/starknet.js?label=npm' />
+  </a>
   <img src='https://img.shields.io/bundlephobia/minzip/starknet?color=success&label=size' />
   <img src='https://img.shields.io/npm/dt/starknet?color=blueviolet' />
   <img src="https://img.shields.io/badge/license-MIT-black">
   <img src='https://img.shields.io/github/stars/seanjameshan/starknet.js?color=yellow' />
   <img src='https://img.shields.io/github/followers/seanjameshan?color=red' />
-  <img src="https://img.shields.io/badge/powered_by-StarkWare-navy">
+  <a href="https://starkware.co/">
+    <img src="https://img.shields.io/badge/powered_by-StarkWare-navy">
+  </a>
 </p>
 
 ## 🕹️ Usage


### PR DESCRIPTION
I added a couple of links to make it easier for users to find the github actions pipeline and the npm link.