### PR TITLE
fix: protect bigints in axios payloads

### DIFF
--- a/src/starknet.ts
+++ b/src/starknet.ts
@@ -12,7 +12,7 @@ import type {
   GetTransactionStatusResponse,
   Transaction,
 } from './types';
-import { parse } from './utils/json';
+import { parse, stringify } from './utils/json';
 import { BigNumberish, toBN, toHex } from './utils/number';
 import { compressProgram, randomAddress } from './utils/starknet';
 
@@ -199,11 +199,15 @@ export function addTransaction(tx: Transaction): Promise<AddTransactionResponse>
 
   return new Promise((resolve, reject) => {
     axios
-      .post(`${GATEWAY_URL}/add_transaction`, {
-        ...tx,
-        ...(Array.isArray(signature) && { signature }), // not needed on deploy tx
-        ...(contract_address_salt && { contract_address_salt }), // not needed on invoke tx
-      })
+      .post(
+        `${GATEWAY_URL}/add_transaction`,
+        stringify({
+          ...tx, // the tx can contain BigInts, so we use our own `stringify`
+          ...(Array.isArray(signature) && { signature }), // not needed on deploy tx
+          ...(contract_address_salt && { contract_address_salt }), // not needed on invoke tx
+        }),
+        { headers: { 'Content-Type': 'application/json' } }
+      )
       .then((resp: any) => {
         resolve(resp.data);
       })


### PR DESCRIPTION
Ran into a problem with `deployContract` where the abi which gets pulled out of the compiled contract json can contain `BigInt`s, which Axios refused to serialize.

An alternative would be to employ Axio's request transformation feature, e.g.: https://itstalwar15.medium.com/handling-bigint-in-axios-using-json-big-in-javascript-d915ae85ffc0

Limitations of this PR:
- No test case, because the work of making a test case would've prevented me from submitting this at all 😅 
- It may be better to [systematically transform axios requests](https://itstalwar15.medium.com/handling-bigint-in-axios-using-json-big-in-javascript-d915ae85ffc0)