### PR TITLE
feat: add computeHashOnElements

### DIFF
--- a/__tests__/utils/utils.test.ts
+++ b/__tests__/utils/utils.test.ts
@@ -59,3 +59,21 @@ describe('getSelectorFromName()', () => {
     );
   });
 });
+describe('computeHashOnElements()', () => {
+  test('should return valid hash for empty array', () => {
+    const res = stark.computeHashOnElements([]);
+    expect(res).toMatchInlineSnapshot(
+      `"0x49ee3eba8c1600700ee1b87eb599f16716b0b1022947733551fde4050ca6804"`
+    );
+  });
+  test('should return valid hash for valid array', () => {
+    const res = stark.computeHashOnElements([
+      number.toBN(123782376),
+      number.toBN(213984),
+      number.toBN(128763521321),
+    ]);
+    expect(res).toMatchInlineSnapshot(
+      `"0x7b422405da6571242dfc245a43de3b0fe695e7021c148b918cd9cdb462cac59"`
+    );
+  });
+});

--- a/src/utils/stark.ts
+++ b/src/utils/stark.ts
@@ -3,7 +3,7 @@ import { gzip } from 'pako';
 import { CompressedProgram, Program } from '../types';
 import { genKeyPair, getStarkKey } from './ellipticCurve';
 import { addHexPrefix, btoaUniversal } from './encode';
-import { starknetKeccak } from './hash';
+import { pedersen, starknetKeccak } from './hash';
 import { stringify } from './json';
 import { BigNumberish, toBN, toHex } from './number';
 
@@ -48,4 +48,8 @@ export function formatSignature(sig?: [BigNumberish, BigNumberish]): [string, st
   } catch (e) {
     return [];
   }
+}
+
+export function computeHashOnElements(data: BigNumberish[]) {
+  return [...data, data.length].reduce((x, y) => pedersen([x, y]), 0);
 }


### PR DESCRIPTION
Implements https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/cairo/common/hash_chain.py in JS which is a very common function to use. 
It'll also be used by wallet implementations in the future.