### PR TITLE
fix: correctly parse structs in Starknet return types

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,11 +1,13 @@
+import BN from 'bn.js';
+
 import { toBN } from './utils/number';
 
 export { IS_BROWSER } from './utils/encode';
 
-export const ZERO = toBN(0);
-export const ONE = toBN(1);
-export const TWO = toBN(2);
-export const MASK_250 = TWO.pow(toBN(250)).sub(ONE); // 2 ** 250 - 1
+export const ZERO: BN = toBN(0);
+export const ONE: BN = toBN(1);
+export const TWO: BN = toBN(2);
+export const MASK_250: BN = TWO.pow(toBN(250)).sub(ONE); // 2 ** 250 - 1
 
 /**
  * The following is taken from https://github.com/starkware-libs/starkex-resources/blob/master/crypto/starkware/crypto/signature/pedersen_params.json but converted to hex, because JS is very bad handling big integers by default

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,13 +16,25 @@ export type Type = 'DEPLOY' | 'INVOKE_FUNCTION';
 export type EntryPointType = 'EXTERNAL';
 export type CompressedProgram = string;
 
-export type Abi = {
-  inputs: { name: string; type: 'felt' | 'felt*' }[];
+export type AbiEntry = { name: string; type: 'felt' | 'felt*' | string };
+
+export type FunctionAbi = {
+  inputs: AbiEntry[];
   name: string;
-  outputs: { name: string; type: 'felt' | 'felt*' }[];
+  outputs: AbiEntry[];
   stateMutability?: 'view';
   type: 'function';
 };
+
+export type StructAbi = {
+  members: { name: string; offset: number; type: 'felt' | 'felt*' | string }[];
+  name: string;
+  size: number;
+  type: 'struct';
+};
+
+export type Abi = FunctionAbi | StructAbi;
+
 export type EntryPointsByType = object;
 export type Program = object;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,7 @@ export type FunctionAbi = {
 };
 
 export type StructAbi = {
-  members: { name: string; offset: number; type: 'felt' | 'felt*' | string }[];
+  members: (AbiEntry & { offset: number })[];
   name: string;
   size: number;
   type: 'struct';


### PR DESCRIPTION
Currently, starknet.js doesn't do a good job with structs, such as the Uint256 struct returned by the ERC20 contract. Instead of returning all the fields of the struct, it just returns the first field.

Concretely, if a user had a balance of 1 in an ERC20 contract, this is what would have been returned from `balance_of` previously:

```json
{ "res": "0x0" }
```

With this change we properly parse the Uint256 struct, so the method will instead return the following:

```json
{ "res": { "low": "0x1", "high": "0x0" } }
```