### PR TITLE
feat: extend signer to sign arbitrary message hashes

### DIFF
--- a/src/signer/default.ts
+++ b/src/signer/default.ts
@@ -1,7 +1,7 @@
 import assert from 'minimalistic-assert';
 
 import { Provider } from '../provider';
-import { AddTransactionResponse, KeyPair, Transaction } from '../types';
+import { AddTransactionResponse, KeyPair, Signature, Transaction } from '../types';
 import { sign } from '../utils/ellipticCurve';
 import { addHexPrefix } from '../utils/encode';
 import { hashMessage } from '../utils/hash';
@@ -18,6 +18,16 @@ export class Signer extends Provider implements SignerInterface {
     super(provider);
     this.keyPair = keyPair;
     this.address = address;
+  }
+
+  /**
+   * Sign a message hash.
+   *
+   * @param msghash - Message hash to be signed.
+   * @returns {r,s} of the signed message
+   */
+  public sign(msghash: string): Signature {
+    return sign(this.keyPair, msghash);
   }
 
   /**

--- a/src/signer/interface.ts
+++ b/src/signer/interface.ts
@@ -1,5 +1,5 @@
 import { Provider } from '../provider';
-import { AddTransactionResponse, Transaction } from '../types';
+import { AddTransactionResponse, Signature, Transaction } from '../types';
 
 export abstract class SignerInterface extends Provider {
   public abstract address: string;
@@ -12,4 +12,12 @@ export abstract class SignerInterface extends Provider {
    * @returns a confirmation of invoking a function on the starknet contract
    */
   public abstract override addTransaction(tx: Transaction): Promise<AddTransactionResponse>;
+
+  /**
+   * Sign a message hash.
+   *
+   * @param msghash - Message hash to be signed.
+   * @returns {r,s} of the signed message
+   */
+  public abstract sign(msghash: string): Signature;
 }


### PR DESCRIPTION
This is a pull request to allow wallets to sign messages without broadcasting them. 

Ethereum had a lot of issues with this, so it will likely require some debate and the establishment of a standard on how messages are signed. See EIP 712 and EIP 191.

https://eips.ethereum.org/EIPS/eip-191
https://eips.ethereum.org/EIPS/eip-712

I know there's a lot of security issues around it, so I don't expect it to get approved without a lot of discussion and additional code, but I wanted to get the ball rolling by putting up some code to start. 