### PR TITLE
fix(types): add block_number property to GetBlockResponse interface

### DIFF
--- a/__tests__/provider.test.ts
+++ b/__tests__/provider.test.ts
@@ -19,6 +19,10 @@ describe('defaultProvider', () => {
     test('getBlock(blockId=null)', () => {
       return expect(defaultProvider.getBlock()).resolves.not.toThrow();
     });
+    test('getBlock() blockNumber', async () => {
+      const block = await defaultProvider.getBlock();
+      return expect(block).toHaveProperty('block_number');
+    });
     test('getCode()', () => {
       return expect(
         defaultProvider.getCode(

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,7 +79,7 @@ export type CallContractResponse = {
 };
 
 export type GetBlockResponse = {
-  sequence_number: number;
+  block_number: number;
   state_root: string;
   block_hash: string;
   transactions: {


### PR DESCRIPTION
- Remove sequence_number property. Seems deprecated.