### PR TITLE
feat: new external signer to handle external signer provider such as Dfns

### DIFF
--- a/src/signer/externalSigner.ts
+++ b/src/signer/externalSigner.ts
@@ -1,0 +1,23 @@
+import { Signature } from '../types';
+import { Signer } from './default';
+import { SignerInterface } from './interface';
+
+export class ExternalSigner extends Signer implements SignerInterface {
+  private readonly pubkey: () => Promise<string>;
+
+  private readonly signHash: (hash: string) => Promise<Signature>;
+
+  constructor(pubkey: () => Promise<string>, signHash: (hash: string) => Promise<Signature>) {
+    super();
+    this.pubkey = pubkey;
+    this.signHash = signHash;
+  }
+
+  public async getPubKey(): Promise<string> {
+    return this.pubkey();
+  }
+
+  protected async signRaw(hash: string): Promise<Signature> {
+    return this.signHash(hash);
+  }
+}

--- a/src/signer/index.ts
+++ b/src/signer/index.ts
@@ -1,6 +1,7 @@
 export * from './interface';
 export * from './default';
 export * from './ethSigner';
+export * from './externalSigner';
 export {
   LedgerSigner111,
   getLedgerPathBuffer111,


### PR DESCRIPTION
## Motivation and Resolution

Before, there was only a default signer with direct access to the private key. I have been using wallet provider such as Dfns which provides signing functions as a service. I derived from the implementation of the default signer, a signer that rely on an external service. I think that it may be useful to have it in the library.

## Usage related changes

- Introduction of a new signer to use external signing service such as Dfns

## Development related changes

- It is based on the default signer. All the method that needs the private key are overwritten to use the external service

## Checklist:

- [ ] Performed a self-review of the code
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [ ] All tests are passing
