### PR TITLE
chore: upgrade Braavos account creation. Handle contract v1.2.0

### DIFF
--- a/www/docs/guides/create_account.md
+++ b/www/docs/guides/create_account.md
@@ -165,9 +165,9 @@ console.log('✅ ArgentX wallet deployed at:', AXcontractFinalAddress);
 
 ## Create a Braavos account
 
-More complicated, a Braavos account needs a proxy and a specific signature. Starknet.js is handling only Starknet standard signatures; so we need extra code to handle this specific signature for account creation. These nearly 400 lines of code are not displayed here but are available in a module [here](./doc_scripts/deployBraavos.ts).
+More complicated, a Braavos account needs a proxy and a specific signature. Starknet.js is handling only Starknet standard signatures; so we need extra code to handle this specific signature for account creation. These more than 200 lines of code are not displayed here but are available in a module [here](./doc_scripts/deployBraavos.ts).
 
-We will deploy hereunder a Braavos account in Devnet. So launch `starknet-devnet` with these parameters:
+We will deploy hereunder a Braavos account in Devnet (use at least v0.3.0). So launch `starknet-devnet` with these parameters:
 
 ```bash
 starknet-devnet --seed 0 --fork-network 'https://free-rpc.nethermind.io/sepolia-juno/v0_8'

--- a/www/docs/guides/doc_scripts/deployBraavos.ts
+++ b/www/docs/guides/doc_scripts/deployBraavos.ts
@@ -1,5 +1,6 @@
-// Collection of functions for Braavos account v1.1.0 creation
-// coded with Starknet.js v7.0.1 (08/apr/2025)
+// Collection of functions for Braavos account v1.2.0 creation.
+// Coded with Starknet.js v7.1.0
+// Handle Rpc0.8V3
 
 import {
   ec,
@@ -10,9 +11,7 @@ import {
   stark,
   BigNumberish,
   type RpcProvider,
-  type V2InvocationsSignerDetails,
   type DeployAccountSignerDetails,
-  type V2DeployAccountSignerDetails,
   type V3DeployAccountSignerDetails,
   type V3InvocationsSignerDetails,
   type UniversalDetails,
@@ -31,24 +30,12 @@ import {
   EDAMode,
   EDataAvailabilityMode,
   ETransactionVersion,
-  ETransactionVersion2,
   ETransactionVersion3,
   type ResourceBounds,
 } from '@starknet-io/types-js';
 
 const BraavosBaseClassHash = '0x3d16c7a9a60b0593bd202f660a28c5d76e0403601d9ccc7e4fa253b6a70c201';
-const BraavosAccountClassHash = '0x2c8c7e6fbcfb3e8e15a46648e8914c6aa1fc506fc1e7fb3d1e19630716174bc';
-
-type CalcV2DeployAccountTxHashArgs = {
-  contractAddress: BigNumberish;
-  classHash: BigNumberish;
-  constructorCalldata: Calldata;
-  salt: BigNumberish;
-  version: `${ETransactionVersion2}`;
-  maxFee: BigNumberish;
-  chainId: constants.StarknetChainId;
-  nonce: BigNumberish;
-};
+const BraavosAccountClassHash = '0x3957f9f5a1cbfe918cedc2015c85200ca51a5f7506ecb6de98a5207b759bf8a'; // v1.2.0
 
 type CalcV3DeployAccountTxHashArgs = {
   contractAddress: BigNumberish;
@@ -69,34 +56,23 @@ export function getBraavosSignature(
   details: DeployAccountSignerDetails,
   privateKeyBraavos: BigNumberish
 ): string[] {
-  const starkKeyPubBraavos = ec.starkCurve.getStarkKey(num.toHex(privateKeyBraavos));
   let txnHash: string = '';
-  if (Object.values(ETransactionVersion3).includes(details.version as any)) {
-    const det = details as V3DeployAccountSignerDetails;
-    const v3det = stark.v3Details(det);
-    txnHash = hash.calculateDeployAccountTransactionHash({
-      contractAddress: det.contractAddress,
-      classHash: det.classHash,
-      compiledConstructorCalldata: det.constructorCalldata,
-      salt: det.addressSalt,
-      version: det.version,
-      chainId: det.chainId,
-      nonce: det.nonce,
-      nonceDataAvailabilityMode: stark.intDAM(v3det.nonceDataAvailabilityMode),
-      feeDataAvailabilityMode: stark.intDAM(v3det.feeDataAvailabilityMode),
-      tip: v3det.tip,
-      paymasterData: v3det.paymasterData,
-      resourceBounds: v3det.resourceBounds,
-    } as CalcV3DeployAccountTxHashArgs);
-  } else if (Object.values(ETransactionVersion2).includes(details.version as any)) {
-    const det = details as V2DeployAccountSignerDetails;
-    txnHash = hash.calculateDeployAccountTransactionHash({
-      ...det,
-      salt: det.addressSalt,
-    } as CalcV2DeployAccountTxHashArgs);
-  } else {
-    throw Error('unsupported signDeployAccountTransaction version');
-  }
+  const det = details as V3DeployAccountSignerDetails;
+  const v3det = stark.v3Details(det, '0.8');
+  txnHash = hash.calculateDeployAccountTransactionHash({
+    contractAddress: det.contractAddress,
+    classHash: det.classHash,
+    compiledConstructorCalldata: det.constructorCalldata,
+    salt: det.addressSalt,
+    version: det.version,
+    chainId: det.chainId,
+    nonce: det.nonce,
+    nonceDataAvailabilityMode: stark.intDAM(v3det.nonceDataAvailabilityMode),
+    feeDataAvailabilityMode: stark.intDAM(v3det.feeDataAvailabilityMode),
+    tip: v3det.tip,
+    paymasterData: v3det.paymasterData,
+    resourceBounds: v3det.resourceBounds,
+  } as CalcV3DeployAccountTxHashArgs);
 
   // braavos v1.0.0 specific deployment signature :
   // sig[0: 1] - r,s from stark sign on txn_hash
@@ -119,13 +95,12 @@ export function getBraavosSignature(
   const signature = [
     r.toString(),
     s.toString(),
-    BraavosAccountClassHash.toString(),
+    BigInt(BraavosAccountClassHash).toString(),
     ...parsedOtherSigner.map((e) => e.toString()),
-    details.chainId.toString(),
+    BigInt(details.chainId).toString(),
     rPoseidon.toString(),
     sPoseidon.toString(),
   ];
-  console.log('Braavos special signature =', signature);
   return signature;
 }
 
@@ -135,7 +110,6 @@ const BraavosConstructor = (starkKeyPubBraavos: string) =>
 export function calculateAddressBraavos(privateKeyBraavos: BigNumberish): string {
   const starkKeyPubBraavos = ec.starkCurve.getStarkKey(num.toHex(privateKeyBraavos));
   const BraavosProxyConstructorCallData = BraavosConstructor(starkKeyPubBraavos);
-
   return hash.calculateContractAddressFromHash(
     starkKeyPubBraavos,
     BraavosBaseClassHash,
@@ -152,58 +126,33 @@ async function buildBraavosAccountDeployPayload(
     constructorCalldata,
     contractAddress: providedContractAddress,
   }: DeployAccountContractPayload,
-  invocationDetails: V2InvocationsSignerDetails | V3InvocationsSignerDetails
+  invocationDetails: V3InvocationsSignerDetails
 ): Promise<DeployAccountContractTransaction> {
   const compiledCalldata = CallData.compile(constructorCalldata ?? []);
   const contractAddress = providedContractAddress ?? calculateAddressBraavos(privateKeyBraavos);
-  if (Object.values(ETransactionVersion3).includes(invocationDetails.version as any)) {
-    const v3invocation = invocationDetails as V3InvocationsSignerDetails;
-    const details: V3DeployAccountSignerDetails = {
-      classHash,
-      constructorCalldata: constructorCalldata ?? [],
-      addressSalt: addressSalt ?? 0,
-      contractAddress,
-      ...v3invocation,
-    };
-    const signature = getBraavosSignature(details, privateKeyBraavos);
-    return {
-      classHash,
-      addressSalt,
-      constructorCalldata: compiledCalldata,
-      signature,
-    };
-  } else if (Object.values(ETransactionVersion2).includes(invocationDetails.version as any)) {
-    //tx V1
-    const v2invocation = invocationDetails as V2InvocationsSignerDetails;
-    const details: V2DeployAccountSignerDetails = {
-      classHash,
-      constructorCalldata: constructorCalldata ?? [],
-      addressSalt: addressSalt ?? 0,
-      contractAddress,
-      ...v2invocation,
-      ...stark.v3Details({}),
-    };
-    const signature = getBraavosSignature(details, privateKeyBraavos);
-    return {
-      classHash,
-      addressSalt,
-      constructorCalldata: compiledCalldata,
-      signature,
-    };
-  } else {
-    throw Error('wrong version in buildBraavosAccountDeployPayload');
-  }
+  const details: V3DeployAccountSignerDetails = {
+    classHash,
+    constructorCalldata: constructorCalldata ?? [],
+    addressSalt: addressSalt ?? 0,
+    contractAddress,
+    ...invocationDetails,
+  };
+  const signature = getBraavosSignature(details, privateKeyBraavos);
+  return {
+    classHash,
+    addressSalt,
+    constructorCalldata: compiledCalldata,
+    signature,
+  };
 }
 
 export async function estimateBraavosAccountDeployFee(
   privateKeyBraavos: BigNumberish,
   provider: RpcProvider,
-  { blockIdentifier, skipValidate, version: txVersion, tip: tip0 }: EstimateFeeDetails
+  { blockIdentifier, skipValidate, tip: tip0 }: EstimateFeeDetails
 ): Promise<UniversalDetails> {
-  console.log('start estimate fees...', txVersion);
   const tip = tip0 ?? 0n;
-  const EstimateVersion =
-    txVersion === ETransactionVersion.V3 ? ETransactionVersion.F3 : ETransactionVersion2.F1;
+  const EstimateVersion = ETransactionVersion.F3;
   const nonce = constants.ZERO;
   const chainId = await provider.getChainId();
   const cairoVersion: CairoVersion = '1'; // dummy value, not used but mandatory
@@ -211,92 +160,57 @@ export async function estimateBraavosAccountDeployFee(
   const BraavosAccountAddress = calculateAddressBraavos(privateKeyBraavos);
   const BraavosConstructorCallData = BraavosConstructor(starkKeyPubBraavos);
 
-  if (EstimateVersion == ETransactionVersion.F3) {
-    // transaction V3 for RPC0.8
-    const payload: DeployAccountContractTransaction = await buildBraavosAccountDeployPayload(
-      privateKeyBraavos,
-      {
-        classHash: BraavosBaseClassHash.toString(),
-        addressSalt: starkKeyPubBraavos,
-        constructorCalldata: BraavosConstructorCallData,
-        contractAddress: BraavosAccountAddress,
-      },
-      {
-        chainId,
-        nonce,
-        version: EstimateVersion,
-        walletAddress: BraavosAccountAddress,
-        cairoVersion: cairoVersion,
-        tip,
-      } as V3InvocationsSignerDetails
-    );
-    console.log('estimate deploy payload V3 =', payload);
-    const v3det = stark.v3Details({}, '0.8');
-    const response: EstimateFeeResponse = await provider.getDeployAccountEstimateFee(
-      {
-        classHash: BraavosBaseClassHash,
-        addressSalt: starkKeyPubBraavos,
-        constructorCalldata: BraavosConstructorCallData,
-        signature: payload.signature,
-      },
-      {
-        nonce,
-        version: EstimateVersion,
-        ...v3det,
-      } as V3TransactionDetails,
-      blockIdentifier,
-      skipValidate
-    );
-    console.log('response estimate fee V3 =', response);
-    const suggestedMaxFee = stark.estimateFeeToBounds({
-      ...response,
-      overall_fee: response.overall_fee.toString(),
-      l1_gas_consumed: response.l1_gas_consumed.toString(),
-      l1_gas_price: response.l1_gas_price.toString(),
-      l2_gas_consumed: (response.l2_gas_consumed ?? 0n).toString(),
-      l2_gas_price: response.l1_data_gas_price.toString(),
-      l1_data_gas_consumed: response.l1_data_gas_consumed.toString(),
-      l1_data_gas_price: response.l1_data_gas_price.toString(),
-    });
-    return {
-      resourceBounds: suggestedMaxFee,
-      feeDataAvailabilityMode: EDataAvailabilityMode.L1,
-      nonceDataAvailabilityMode: EDataAvailabilityMode.L1,
-      tip: 10 ** 13, // not handled in Starknet 0.13.3
-      paymasterData: [],
-    };
-  } else {
-    // V1 tx
-    const payload: DeployAccountContractTransaction = await buildBraavosAccountDeployPayload(
-      privateKeyBraavos,
-      {
-        classHash: BraavosBaseClassHash,
-        addressSalt: starkKeyPubBraavos,
-        constructorCalldata: BraavosConstructorCallData,
-        contractAddress: BraavosAccountAddress,
-      },
-      {
-        nonce,
-        chainId,
-        version: EstimateVersion,
-        walletAddress: BraavosAccountAddress,
-        maxFee: constants.ZERO,
-        cairoVersion: cairoVersion,
-      } as V2InvocationsSignerDetails
-    );
-    console.log('estimate payload V1 =', payload);
-
-    const response = await provider.getDeployAccountEstimateFee(
-      { ...payload },
-      { version: EstimateVersion, nonce },
-      blockIdentifier,
-      skipValidate
-    );
-    console.log('response estimate fee V1 =', response);
-    const suggestedMaxFee = stark.estimatedFeeToMaxFee(response.overall_fee);
-
-    return { maxFee: suggestedMaxFee };
-  }
+  // transaction V3 for RPC0.8
+  const payload: DeployAccountContractTransaction = await buildBraavosAccountDeployPayload(
+    privateKeyBraavos,
+    {
+      classHash: BraavosBaseClassHash.toString(),
+      addressSalt: starkKeyPubBraavos,
+      constructorCalldata: BraavosConstructorCallData,
+      contractAddress: BraavosAccountAddress,
+    },
+    {
+      chainId,
+      nonce,
+      version: EstimateVersion,
+      walletAddress: BraavosAccountAddress,
+      cairoVersion: cairoVersion,
+      tip,
+    } as V3InvocationsSignerDetails
+  );
+  const v3det = stark.v3Details({}, await provider.getSpecVersion());
+  const response: EstimateFeeResponse = await provider.getDeployAccountEstimateFee(
+    {
+      classHash: BraavosBaseClassHash,
+      addressSalt: starkKeyPubBraavos,
+      constructorCalldata: BraavosConstructorCallData,
+      signature: payload.signature,
+    },
+    {
+      nonce,
+      version: EstimateVersion,
+      ...v3det,
+    } as V3TransactionDetails,
+    blockIdentifier,
+    skipValidate
+  );
+  const suggestedMaxFee = stark.estimateFeeToBounds({
+    ...response,
+    overall_fee: Number(response.overall_fee),
+    l1_gas_consumed: Number(response.l1_gas_consumed),
+    l1_gas_price: Number(response.l1_gas_price),
+    l2_gas_consumed: Number(response.l2_gas_consumed ?? 0n),
+    l2_gas_price: Number(response.l2_gas_price ?? 0n),
+    l1_data_gas_consumed: Number(response.l1_data_gas_consumed),
+    l1_data_gas_price: Number(response.l1_data_gas_price),
+  });
+  return {
+    resourceBounds: suggestedMaxFee,
+    feeDataAvailabilityMode: EDataAvailabilityMode.L1,
+    nonceDataAvailabilityMode: EDataAvailabilityMode.L1,
+    tip: 10 ** 13, // not handled in Starknet 0.13.5
+    paymasterData: [],
+  };
 }
 
 type Version = typeof ETransactionVersion.V3 | typeof ETransactionVersion.F3;
@@ -307,8 +221,7 @@ export function isV3tx(version: string): boolean {
 export async function deployBraavosAccount(
   privateKeyBraavos: BigNumberish,
   provider: RpcProvider,
-  maxFeeDetails?: UniversalDetails,
-  txVersion: ETransactionVersion = ETransactionVersion.V3
+  maxFeeDetails?: UniversalDetails
 ): Promise<DeployContractResponse> {
   const nonce = constants.ZERO;
   const chainId = await provider.getChainId();
@@ -317,73 +230,36 @@ export async function deployBraavosAccount(
   const BraavosAccountAddress = calculateAddressBraavos(privateKeyBraavos);
   const BraavosConstructorCallData = BraavosConstructor(starkKeyPubBraavos);
   const feeDetails: UniversalDetails =
-    maxFeeDetails ??
-    (await estimateBraavosAccountDeployFee(privateKeyBraavos, provider, { version: txVersion }));
-  const isV3 = isV3tx(txVersion);
-  if (isV3) {
-    const payload: DeployAccountContractTransaction = await buildBraavosAccountDeployPayload(
-      privateKeyBraavos,
-      {
-        classHash: BraavosBaseClassHash.toString(),
-        addressSalt: starkKeyPubBraavos,
-        constructorCalldata: BraavosConstructorCallData,
-        contractAddress: BraavosAccountAddress,
-      },
-      {
-        chainId,
-        nonce,
-        version: txVersion,
-        walletAddress: BraavosAccountAddress,
-        cairoVersion: cairoVersion,
-        ...feeDetails,
-      } as V3InvocationsSignerDetails
-    );
-    console.log('deploy payload V3 =', payload);
-    return provider.deployAccountContract(
-      {
-        classHash: BraavosBaseClassHash,
-        addressSalt: starkKeyPubBraavos,
-        constructorCalldata: BraavosConstructorCallData,
-        signature: payload.signature,
-      },
-      {
-        nonce,
-        version: txVersion,
-        ...feeDetails,
-      }
-    );
-  } else {
-    // V1 tx
-    const payload: DeployAccountContractTransaction = await buildBraavosAccountDeployPayload(
-      privateKeyBraavos,
-      {
-        classHash: BraavosBaseClassHash.toString(),
-        addressSalt: starkKeyPubBraavos,
-        constructorCalldata: BraavosConstructorCallData,
-        contractAddress: BraavosAccountAddress,
-      },
-      {
-        nonce,
-        chainId,
-        version: txVersion as ETransactionVersion2,
-        walletAddress: BraavosAccountAddress,
-        maxFee: feeDetails.maxFee as BigNumberish,
-        cairoVersion: cairoVersion,
-      }
-    );
-    console.log('deploy payload V1 =', payload);
-    return provider.deployAccountContract(
-      {
-        classHash: BraavosBaseClassHash,
-        addressSalt: starkKeyPubBraavos,
-        constructorCalldata: BraavosConstructorCallData,
-        signature: payload.signature,
-      },
-      {
-        nonce,
-        maxFee: feeDetails.maxFee,
-        version: txVersion,
-      }
-    );
-  }
+    maxFeeDetails ?? (await estimateBraavosAccountDeployFee(privateKeyBraavos, provider, {}));
+  const txVersion = ETransactionVersion.V3;
+  const payload: DeployAccountContractTransaction = await buildBraavosAccountDeployPayload(
+    privateKeyBraavos,
+    {
+      classHash: BraavosBaseClassHash.toString(),
+      addressSalt: starkKeyPubBraavos,
+      constructorCalldata: BraavosConstructorCallData,
+      contractAddress: BraavosAccountAddress,
+    },
+    {
+      chainId,
+      nonce,
+      version: txVersion,
+      walletAddress: BraavosAccountAddress,
+      cairoVersion: cairoVersion,
+      ...feeDetails,
+    } as V3InvocationsSignerDetails
+  );
+  return provider.deployAccountContract(
+    {
+      classHash: BraavosBaseClassHash,
+      addressSalt: starkKeyPubBraavos,
+      constructorCalldata: BraavosConstructorCallData,
+      signature: payload.signature,
+    },
+    {
+      nonce,
+      version: txVersion,
+      ...feeDetails,
+    }
+  );
 }


### PR DESCRIPTION
## Motivation and Resolution
Current guide is showing how to deploy a Braavos V1.1.0 account, but this version is working only with RPC 0.7, and is not working with RPC 0.8.
Braavos just released v1.2.0 contract, that is only working in RPC0.8 (RPC 0.7 v1 & V3 signatures are not handled).

The guide is updated to handle this new contract version

## Usage related changes

N/A only documentation stuff.

## Development related changes
N/A

## Checklist:

- [x] Rebased to the last commit of the target branch (or merged it into my branch)
