### PR TITLE
fix dead link L1message.md

### DIFF
--- a/www/versioned_docs/version-6.11.0/guides/L1message.md
+++ b/www/versioned_docs/version-6.11.0/guides/L1message.md
@@ -10,7 +10,7 @@ You can exchange messages between L1 & L2 networks:
 - L2 Starknet testnet ↔️ L1 Sepolia ETH testnet.
 - L2 local Starknet devnet ↔️ L1 local ETH testnet (Ganache, ...).
 
-You can find an explanation of the global mechanism [here](https://docs.starknet.io/documentation/architecture_and_concepts/L1-L2_Communication/messaging-mechanism/).
+You can find an explanation of the global mechanism [here](https://docs.starknet.io/architecture-and-concepts/smart-contracts/system-calls-cairo1/#send_message_to_L1).
 
 Most of the code for this messaging process will be written in Cairo, but Starknet.js provides some functionalities for this subject.
 


### PR DESCRIPTION
Hey team—noticed a dead link, replaced it with a working URL. Thanks!

https://docs.starknet.io/documentation/architecture_and_concepts/L1-L2_Communication/messaging-mechanism/ - OLD
https://docs.starknet.io/architecture-and-concepts/smart-contracts/system-calls-cairo1/#send_message_to_L1 - NEW