### PR TITLE
docs: remove tab added by lint

### DIFF
--- a/www/docs/guides/paymaster.md
+++ b/www/docs/guides/paymaster.md
@@ -141,12 +141,10 @@ const txR = await myProvider.waitForTransaction(res.transaction_hash);
 Optional execution window with `executeAfter` and `executeBefore` dates:
 
 ```typescript
-const lastBlockTimestamp = (await myProvider.getBlock()).timestamp;
 const feesDetails: PaymasterDetails = {
   feeMode: { mode: 'default', gasToken },
   timeBounds: {
-    executeAfter: lastBlockTimestamp - 1,
-    executeBefore: lastBlockTimestamp + 60 * 5, // 5 minutes
+    executeBefore: Math.floor(Date.now() / 1000) + 60 * 5, // 5 minutes
   },
 };
 ```
@@ -154,8 +152,9 @@ const feesDetails: PaymasterDetails = {
 :::note
 
 - Time unit is the Starknet blockchain time unit: seconds.
-- `executeAfter` must be strictly lower than the timestamp of the last block if you want to be able to process immediately.
-- `executeBefore` is valid up until a block with a higher timestamp is created. It means that even if the Unix time is higher than executeBefore, the transaction is still possible ; only the last block timeStamp is the reference.
+- `executeAfter` is optional. If omitted, the transaction can be executed immediately.
+- if `executeAfter` is defined, it must be strictly lower than the timestamp of the last block if you want to be able to process immediately.
+- `executeBefore`: the transaction is possible as long as the Unix time of the SNIP-29 server is lower than executeBefore.
 
 :::
 


### PR DESCRIPTION
## Motivation and Resolution
prettier is adding unexpected spaces before Docusaurus notes.
before :
```
:::note
sdfgsdfg
:::
```

after :
```
   :::note
sdfgsdfg
:::
```

These spaces are generating a mess in the display:
> ![image](https://github.com/user-attachments/assets/7a4e7e44-5914-4ba7-a940-ef8ec59634f4)

A workaround is to add an empty line after the note creation, and add an empty line before closure:
```
:::note

sdfgsdfg

:::
```
Then prettier is no more corrupting the md file:
> ![image](https://github.com/user-attachments/assets/e5ab2d4e-84d2-49be-935c-af78372f19ab)

I also added some details in timeBounds chapter.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
