### PR TITLE
fix: remove unused Paymaster property in UniversalDetails

### DIFF
--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -39,7 +39,6 @@ export interface UniversalDetails {
   blockIdentifier?: BlockIdentifier;
   maxFee?: BigNumberish; // ignored on estimate
   tip?: BigNumberish;
-  paymaster?: PaymasterDetails;
   paymasterData?: BigNumberish[];
   accountDeploymentData?: BigNumberish[];
   nonceDataAvailabilityMode?: EDataAvailabilityMode;


### PR DESCRIPTION
## Motivation and Resolution
In UniversalDetails:
```typescript
export interface UniversalDetails {
  nonce?: BigNumberish;
  blockIdentifier?: BlockIdentifier;
  maxFee?: BigNumberish; // ignored on estimate
  tip?: BigNumberish;
  paymaster?: PaymasterDetails;
  paymasterData?: BigNumberish[];
  accountDeploymentData?: BigNumberish[];
  nonceDataAvailabilityMode?: EDataAvailabilityMode;
  feeDataAvailabilityMode?: EDataAvailabilityMode;
  version?: BigNumberish;
  resourceBounds?: ResourceBounds; // ignored on estimate
  skipValidate?: boolean; // ignored on non-estimate
}
```
`paymaster` property is finally useless, but it has not been removed.

Removed by this PR.

## Usage related change
A user could try to process this, thinking he was processing a Paymaster transaction :
```typescript
const res2 = await account0.execute(
    [myCall],
    {paymaster:{
        feeMode: { mode: "default", gasToken },
    }
    }
  );
  ```
  But in fact it was a normal transaction that was processed.
  Now, it's no more possible.

## Development related changes
N/A

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] All tests are passing
