### PR TITLE
fix: verification of signature in a Braavos account with a juno node …

### DIFF
--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -577,8 +577,10 @@ export class RpcProvider implements ProviderInterface {
         '0x00', // OpenZeppelin 0.7.0 to 0.9.0 invalid signature
       ],
       error: [
-        'argent/invalid-signature', // ArgentX 0.3.0 to 0.3.1
-        'is invalid, with respect to the public key', // OpenZeppelin until 0.6.1, Braavos 0.0.11
+        'argent/invalid-signature',
+        '0x617267656e742f696e76616c69642d7369676e6174757265', // ArgentX 0.3.0 to 0.3.1
+        'is invalid, with respect to the public key',
+        '0x697320696e76616c6964', // OpenZeppelin until 0.6.1, Braavos 0.0.11
         'INVALID_SIG',
         '0x494e56414c49445f534947', // Braavos 1.0.0
       ],


### PR DESCRIPTION
…is throwing an error

## Motivation and Resolution
Normally, when using a wrong signature with `myProvider.verifyMessageInStarknet()`, the result should be FALSE.
When using a Braavos account with a Juno node, we don't have a FALSE response ; we have a Starknet error 40. With Pathfinder, it works as expected.
In case of wrong signature:
- Pathfinder is failing with this message:
```
"0x494e56414c49445f534947 ('INVALID_SIG').\n"
```
The current code is searching the string `INVALID_SIG` ... and find it, then return FALSE.
- Juno is failing with this message:
```
 40: Contract error: {"revert_error":"0x494e56414c49445f534947"}
 ```
 The current code is searching the string `INVALID_SIG` ... and do not find it, then throw an error.

## Usage related changes
bug fixed. Also corrected for other old accounts.

## Development related changes
Just added the non decoded error message in the list of accepted errors.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] All tests are passing
