### PR TITLE
build: update checkout action to v5

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -20,7 +20,7 @@ jobs:
     name: Run release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
       - uses: actions/setup-node@v4

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -49,7 +49,7 @@ jobs:
       TEST_ACCOUNT_ADDRESS: ${{ secrets.TEST_ACCOUNT_ADDRESS }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*

--- a/.github/workflows/manual-docs-deploy-pages.yml
+++ b/.github/workflows/manual-docs-deploy-pages.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: github-pages
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*

--- a/.github/workflows/manual-docs-version-pr.yml
+++ b/.github/workflows/manual-docs-version-pr.yml
@@ -11,7 +11,7 @@ jobs:
     name: Documentation build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*


### PR DESCRIPTION
Maintenance update to actions/checkout@v5 to align with the current runner stack (Node 24); nothing else modified.

Release notes: https://github.com/actions/checkout/releases/tag/v5.0.0