### PR TITLE
fix: TS inheritance error with `ProviderInterface`

### DIFF
--- a/src/account/interface.ts
+++ b/src/account/interface.ts
@@ -49,7 +49,7 @@ import type { DeployContractUDCResponse } from '../deployer/types/index.type';
  * - Transaction signing with the account's private key
  * - Interaction with the account contract's __execute__ entrypoint
  */
-export abstract class AccountInterface extends ProviderInterface {
+export abstract class AccountInterface implements ProviderInterface {
   /**
    * The address of the account contract on Starknet
    */


### PR DESCRIPTION
## Motivation and Resolution

replaced `extends` with `implements` since `ProviderInterface` is an interface, not a class.
using `extends` caused a TS2689 compiler error. now the class correctly implements the interface and compiles without issues.

### RPC version (if applicable)


## Usage related changes


## Development related changes


## Checklist:

- [x] Performed a self-review of the code
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [x] All tests are passing
