### PR TITLE
fix(utils): fetch bindings

### DIFF
--- a/src/utils/connect/fetch.ts
+++ b/src/utils/connect/fetch.ts
@@ -1,8 +1,8 @@
 import { LibraryError } from '../errors';
 
-export default (typeof globalThis?.fetch !== 'undefined' && globalThis.fetch.bind(globalThis)) ||
-  (typeof window?.fetch !== 'undefined' && window.fetch.bind(window)) ||
-  (typeof global?.fetch !== 'undefined' && global.fetch.bind(global)) ||
+export default (typeof globalThis !== 'undefined' && typeof globalThis.fetch !== 'undefined' && globalThis.fetch.bind(globalThis)) ||
+  (typeof window !== 'undefined' && typeof window.fetch !== 'undefined' && window.fetch.bind(window)) ||
+  (typeof global !== 'undefined' && typeof global.fetch !== 'undefined' && global.fetch.bind(global)) ||
   ((() => {
     throw new LibraryError(
       "'fetch()' not detected, use the 'baseFetch' constructor parameter to set it"


### PR DESCRIPTION
## Motivation and Resolution

When running tests with Jest using `testEnvironment: "jsdom"` to simulate a browser environment, `globalThis` is defined but `globalThis.fetch` is removed by Jest.

When using Starknet's Javascript library, we end up with the following error in tests:
> TypeError: Cannot read properties of undefined (reading 'bind')

This is a fix to remediate that issue.

## Usage related changes

N/A

## Development related changes

N/A

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [ ] All tests are passing
