### PR TITLE
fix(docs): correct TokenData field names in paymaster guide

### DIFF
--- a/www/docs/guides/account/paymaster.md
+++ b/www/docs/guides/account/paymaster.md
@@ -290,7 +290,7 @@ const App: FC = () => {
       {!gasToken && <p>Select a gas token</p>}
       <div>
         {account && (
-          <button disabled={loading} onClick={onClickExecute}>
+          <button disabled={loading || !gasToken} onClick={onClickExecute}>
             {loading ? 'Loading' : 'Execute'}
           </button>
         )}


### PR DESCRIPTION
Replace incorrect field names (address, tokenAddress) with token_address in React example and output sample. 

Add null check for gasToken before use.

Fix matches the actual TokenData interface structure.