### PR TITLE
feat: ressourceBounds are taking into account L2_MIN_PRICE

### DIFF
--- a/__tests__/utils/num.test.ts
+++ b/__tests__/utils/num.test.ts
@@ -233,3 +233,17 @@ describe('toStorageKey, toHex64', () => {
     expect(key4.length).toEqual(66);
   });
 });
+
+describe('min max of bigint array', () => {
+  test('bigIntMax should return the maximum bigint', () => {
+    const values = [10n, 5n, 20n, 3n];
+    const result = num.bigIntMax(...values);
+    expect(result).toBe(20n);
+  });
+
+  test('bigIntMin should return the minimum bigint', () => {
+    const values = [10n, 5n, 20n, 3n];
+    const result = num.bigIntMin(...values);
+    expect(result).toBe(3n);
+  });
+});

--- a/__tests__/utils/stark.test.ts
+++ b/__tests__/utils/stark.test.ts
@@ -8,6 +8,7 @@ import {
   EDataAvailabilityMode,
   ETransactionVersion,
   ArraySignatureType,
+  constants,
 } from '../../src';
 import sampleContract from '../../__mocks__/cairo/helloCairo2/compiled.sierra.json';
 
@@ -247,7 +248,7 @@ describe('stark', () => {
       expect(result.l1_gas.max_amount).toBe(2000n); // 1000 + 100%
       expect(result.l1_gas.max_price_per_unit).toBe(200n); // 100 + 100%
       expect(result.l2_gas.max_amount).toBe(400n); // 200 + 100%
-      expect(result.l2_gas.max_price_per_unit).toBe(40n); // 20 + 100%
+      expect(result.l2_gas.max_price_per_unit).toBe(constants.L2_MIN_PRICE);
     });
 
     test('calculates resource bounds with default overhead', () => {
@@ -257,7 +258,7 @@ describe('stark', () => {
         l1_data_gas_consumed: '500',
         l1_data_gas_price: '50',
         l2_gas_consumed: '200',
-        l2_gas_price: '20',
+        l2_gas_price: '4000000000',
         overall_fee: '0',
         unit: 'FRI',
       };
@@ -271,7 +272,7 @@ describe('stark', () => {
       expect(result.l1_gas.max_amount).toBe(1500n);
       expect(result.l1_gas.max_price_per_unit).toBe(150n);
       expect(result.l2_gas.max_amount).toBe(300n);
-      expect(result.l2_gas.max_price_per_unit).toBe(30n);
+      expect(result.l2_gas.max_price_per_unit).toBe(6000000000n);
       expect(result.l1_data_gas.max_amount).toBe(750n);
       expect(result.l1_data_gas.max_price_per_unit).toBe(75n);
     });
@@ -294,7 +295,7 @@ describe('stark', () => {
       expect(result.l1_gas.max_amount).toBe(1000n);
       expect(result.l1_gas.max_price_per_unit).toBe(100n);
       expect(result.l2_gas.max_amount).toBe(200n);
-      expect(result.l2_gas.max_price_per_unit).toBe(20n);
+      expect(result.l2_gas.max_price_per_unit).toBe(constants.L2_MIN_PRICE);
       expect(result.l1_data_gas.max_amount).toBe(500n);
       expect(result.l1_data_gas.max_price_per_unit).toBe(50n);
     });
@@ -486,7 +487,7 @@ describe('stark', () => {
         },
         l2_gas: {
           max_amount: 0n,
-          max_price_per_unit: 0n,
+          max_price_per_unit: constants.L2_MIN_PRICE,
         },
         l1_data_gas: {
           max_amount: 0n,

--- a/src/global/constants.ts
+++ b/src/global/constants.ts
@@ -185,3 +185,5 @@ export const SYSTEM_MESSAGES = {
   consensusFailed: 'Consensus failed to finalize the block proposal',
   txFailsBlockBuildingValidation: 'Transaction fails block building validation',
 };
+
+export const L2_MIN_PRICE = 3n * 10n ** 9n; // 3 Gwei

--- a/src/provider/modules/tip.ts
+++ b/src/provider/modules/tip.ts
@@ -384,7 +384,7 @@ async function getTipStatsSequential(
 
     // Handle insufficient transaction data
     if (allTips.length < minTxsNecessary) {
-      logger.error(
+      logger.warn(
         `Insufficient transaction data: found ${allTips.length} V3 transactions with tips in ${blocksAnalyzed} blocks ` +
           `(block range: ${Math.max(0, startingBlockNumber - maxBlocks + 1)}-${startingBlockNumber}). ` +
           `Required: ${minTxsNecessary} transactions. Consider reducing minTxsNecessary or increasing maxBlocks.`

--- a/src/utils/num.ts
+++ b/src/utils/num.ts
@@ -407,3 +407,37 @@ export function getNext(iterator: Iterator<string>): string {
   if (it.done) throw new Error('Unexpected end of response');
   return it.value;
 }
+
+/**
+ * Get the maximum bigint from a list of bigints
+ * @param values - a collection of bigint values.
+ * @returns the largest bigint among the provided values.
+ * @example
+ * ```ts
+ * const res = bigIntMax(10n, 5n, 20n, 3n);
+ * // res = 20n
+ * ```
+ */
+export function bigIntMax(...values: bigint[]): bigint {
+  if (values.length === 0) {
+    throw new Error('Empty list in bigintMax.');
+  }
+  return values.reduce((max, current) => (current > max ? current : max), 0n);
+}
+
+/**
+ * Get the minimum bigint from a list of bigints
+ * @param values - a collection of bigint values.
+ * @returns the smallest bigint among the provided values.
+ * @example
+ * ```ts
+ * const res = bigIntMin(10n, 5n, 20n, 3n);
+ * // res = 3n
+ * ```
+ */
+export function bigIntMin(...values: bigint[]): bigint {
+  if (values.length === 0) {
+    throw new Error('Empty list in bigintMin.');
+  }
+  return values.reduce((max, current) => (current < max ? current : max), values[0]);
+}

--- a/src/utils/stark/index.ts
+++ b/src/utils/stark/index.ts
@@ -29,11 +29,13 @@ import {
 import { parse, stringify } from '../json';
 import {
   addPercent,
+  bigIntMax,
   bigNumberishArrayToDecimalStringArray,
   bigNumberishArrayToHexadecimalStringArray,
   toHex,
 } from '../num';
 import { isBigInt, isObject, isString } from '../typed';
+import { L2_MIN_PRICE } from '../../global/constants';
 
 type V3Details = Required<
   Pick<
@@ -184,6 +186,7 @@ export function zeroResourceBounds(): ResourceBoundsBN {
 
 /**
  * Calculates the maximum resource bounds for fee estimation.
+ * Ensure that L2_MIN_PRICE is respected for l2_gas max_price_per_unit.
  *
  * @param {FeeEstimate} estimate The estimate for the fee.
  * @param {ResourceBoundsOverhead | false} [overhead] - The percentage overhead added to the max units and max price per unit. Pass `false` to disable overhead.
@@ -200,9 +203,12 @@ export function toOverheadResourceBounds(
         estimate.l2_gas_consumed,
         overhead !== false ? overhead.l2_gas.max_amount : 0
       ),
-      max_price_per_unit: addPercent(
-        estimate.l2_gas_price,
-        overhead !== false ? overhead.l2_gas.max_price_per_unit : 0
+      max_price_per_unit: bigIntMax(
+        L2_MIN_PRICE,
+        addPercent(
+          estimate.l2_gas_price,
+          overhead !== false ? overhead.l2_gas.max_price_per_unit : 0
+        )
       ),
     },
     l1_gas: {


### PR DESCRIPTION
## Motivation and Resolution
`estimateFee` is providing a `resourceBound` object that is not taking into account L2 MIN PRICE.
This value is 3 Gfri, and is defined in  https://governance.starknet.io/voting-proposals/9

## Usage related changes
Today, if `l2.max_price_per_unit` is lower than L2_MIN_PRICE, the node will answer with an error 53.
Now, automatic definition of resourceBounds is taking care of L2_MIN_PRICE and is not generating errors.
User can anyway defines manually resourceBounds with any (possibly invalid) value.

## Development related changes
Just added 2 functions to get min and max of a collection of bigints.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
