### PR TITLE
Change tip alert

### DIFF
--- a/src/provider/modules/tip.ts
+++ b/src/provider/modules/tip.ts
@@ -316,7 +316,7 @@ async function getTipStatsParallel(
 
     // Handle insufficient transaction data
     if (allTips.length < minTxsNecessary) {
-      logger.error(
+      logger.warn(
         `Insufficient transaction data: found ${allTips.length} V3 transactions with tips in ${analyzedBlocks} blocks ` +
           `(block range: ${Math.max(0, startingBlockNumber - maxBlocks + 1)}-${startingBlockNumber}). ` +
           `Required: ${minTxsNecessary} transactions. Consider reducing minTxsNecessary or increasing maxBlocks.`


### PR DESCRIPTION
## Motivation and Resolution
Devs are complaining to have a flood of error messages when using snjs Devnet, integration or Testnet networks.
Estimation of tip is optimized for Mainnet, but is generating a lot of error messages when using other networks, due to a low quantity of transactions per block.
To be less disruptive for devs, I propose to replace the error message by a warning message.

## Usage related changes
In node.js, jest tests, browser console, very aggressive error messages are now replaced by warnings. 

## Development related changes
> [!NOTE]
> https://github.com/starknet-io/starknet.js/blob/27f2a9b85cbb74dbc1865c339f45c60226850214/src/provider/modules/tip.ts#L386-L392
> I ask me if it's a good idea to return a zero value if not enough txs have been found.
> It could be better to respond zero only if nothing has been found, and in other cases, try to calculate the tip.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] All tests are passing
