### PR TITLE
fix: optional type narrow: getEvents, getTransactionTrace, estimateMe…

### DIFF
--- a/__tests__/providerNarrowing.test.ts
+++ b/__tests__/providerNarrowing.test.ts
@@ -1,0 +1,225 @@
+import { RpcProvider, constants } from '../src';
+import { RPCSPEC09, RPCSPEC010 } from '../src/types/api';
+
+describe('Provider Type Narrowing', () => {
+  let provider: RpcProvider;
+
+  beforeAll(async () => {
+    // Create a mock provider instance to test type narrowing without actual API calls
+    provider = new RpcProvider({ nodeUrl: 'http://localhost:5050', specVersion: '0.10.0' });
+  });
+
+  describe('getEvents', () => {
+    test('should narrow to RPCSPEC010.EVENTS_CHUNK when using v0.10.0', async () => {
+      // Mock the getEvents method to avoid actual API calls
+      const mockEventsChunk: RPCSPEC010.EVENTS_CHUNK = {
+        events: [],
+        continuation_token: undefined,
+      };
+      jest.spyOn(provider, 'getEvents').mockResolvedValueOnce(mockEventsChunk);
+
+      const filter: RPCSPEC010.EventFilter = {
+        from_block: { block_number: 0 },
+        to_block: { block_number: 10 },
+        chunk_size: 10,
+      };
+
+      const result = await provider.getEvents<typeof constants.SupportedRpcVersion.v0_10_0>(filter);
+
+      // Type assertion to verify the type is correctly narrowed to RPCSPEC010.EVENTS_CHUNK
+      const typeCheck: RPCSPEC010.EVENTS_CHUNK = result;
+      expect(typeCheck).toBeDefined();
+      expect('events' in result).toBe(true);
+    });
+
+    test('should narrow to RPCSPEC09.EVENTS_CHUNK when using v0.9.0', async () => {
+      // Mock the getEvents method to avoid actual API calls
+      const mockEventsChunk: RPCSPEC09.EVENTS_CHUNK = {
+        events: [],
+        continuation_token: undefined,
+      };
+      jest.spyOn(provider, 'getEvents').mockResolvedValueOnce(mockEventsChunk);
+
+      const filter: RPCSPEC09.EventFilter = {
+        from_block: { block_number: 0 },
+        to_block: { block_number: 10 },
+        chunk_size: 10,
+      };
+
+      const result = await provider.getEvents<typeof constants.SupportedRpcVersion.v0_9_0>(filter);
+
+      // Type assertion to verify the type is correctly narrowed to RPCSPEC09.EVENTS_CHUNK
+      const typeCheck: RPCSPEC09.EVENTS_CHUNK = result;
+      expect(typeCheck).toBeDefined();
+      expect('events' in result).toBe(true);
+    });
+
+    test('should return union type when no version specified', async () => {
+      // Mock the getEvents method to avoid actual API calls
+      const mockEventsChunk: RPCSPEC010.EVENTS_CHUNK | RPCSPEC09.EVENTS_CHUNK = {
+        events: [],
+        continuation_token: undefined,
+      };
+      jest.spyOn(provider, 'getEvents').mockResolvedValueOnce(mockEventsChunk);
+
+      const filter: RPCSPEC010.EventFilter | RPCSPEC09.EventFilter = {
+        from_block: { block_number: 0 },
+        to_block: { block_number: 10 },
+        chunk_size: 10,
+      };
+
+      const result = await provider.getEvents(filter);
+
+      // Type is union: RPCSPEC010.EVENTS_CHUNK | RPCSPEC09.EVENTS_CHUNK
+      const typeCheck: RPCSPEC010.EVENTS_CHUNK | RPCSPEC09.EVENTS_CHUNK = result;
+      expect(typeCheck).toBeDefined();
+      expect('events' in result).toBe(true);
+    });
+  });
+
+  describe('getTransactionTrace', () => {
+    test('should narrow to RPCSPEC010.TRANSACTION_TRACE when using v0.10.0', async () => {
+      // This test verifies type narrowing at compile time
+      type ResultType = Awaited<
+        ReturnType<
+          typeof provider.getTransactionTrace<typeof constants.SupportedRpcVersion.v0_10_0>
+        >
+      >;
+      type ExpectedType = RPCSPEC010.TRANSACTION_TRACE;
+
+      // Type-level assertion
+      const typeCheck: ResultType extends ExpectedType ? true : false = true;
+      expect(typeCheck).toBe(true);
+    });
+
+    test('should narrow to RPCSPEC09.TRANSACTION_TRACE when using v0.9.0', async () => {
+      // This test verifies type narrowing at compile time
+      type ResultType = Awaited<
+        ReturnType<typeof provider.getTransactionTrace<typeof constants.SupportedRpcVersion.v0_9_0>>
+      >;
+      type ExpectedType = RPCSPEC09.TRANSACTION_TRACE;
+
+      // Type-level assertion
+      const typeCheck: ResultType extends ExpectedType ? true : false = true;
+      expect(typeCheck).toBe(true);
+    });
+
+    test('should return union type when no version specified', async () => {
+      type ResultType = Awaited<ReturnType<typeof provider.getTransactionTrace>>;
+      type ExpectedType = RPCSPEC010.TRANSACTION_TRACE | RPCSPEC09.TRANSACTION_TRACE;
+
+      // Type-level assertion - union type should be assignable to both directions
+      const typeCheck: ResultType extends ExpectedType ? true : false = true;
+      expect(typeCheck).toBe(true);
+    });
+  });
+
+  describe('estimateMessageFee', () => {
+    test('should narrow to RPCSPEC010.FEE_ESTIMATE when using v0.10.0', async () => {
+      type ResultType = Awaited<
+        ReturnType<typeof provider.estimateMessageFee<typeof constants.SupportedRpcVersion.v0_10_0>>
+      >;
+      type ExpectedType = RPCSPEC010.FEE_ESTIMATE;
+
+      const typeCheck: ResultType extends ExpectedType ? true : false = true;
+      expect(typeCheck).toBe(true);
+    });
+
+    test('should narrow to RPCSPEC09.MESSAGE_FEE_ESTIMATE when using v0.9.0', async () => {
+      type ResultType = Awaited<
+        ReturnType<typeof provider.estimateMessageFee<typeof constants.SupportedRpcVersion.v0_9_0>>
+      >;
+      type ExpectedType = RPCSPEC09.MESSAGE_FEE_ESTIMATE;
+
+      const typeCheck: ResultType extends ExpectedType ? true : false = true;
+      expect(typeCheck).toBe(true);
+    });
+
+    test('should return union type when no version specified', async () => {
+      type ResultType = Awaited<ReturnType<typeof provider.estimateMessageFee>>;
+      type ExpectedType = RPCSPEC010.FEE_ESTIMATE | RPCSPEC09.MESSAGE_FEE_ESTIMATE;
+
+      const typeCheck: ResultType extends ExpectedType ? true : false = true;
+      expect(typeCheck).toBe(true);
+    });
+  });
+
+  describe('getL1MessagesStatus', () => {
+    test('should narrow to RPCSPEC010.L1L2MessagesStatus when using v0.10.0', async () => {
+      type ResultType = Awaited<
+        ReturnType<
+          typeof provider.getL1MessagesStatus<typeof constants.SupportedRpcVersion.v0_10_0>
+        >
+      >;
+      type ExpectedType = RPCSPEC010.L1L2MessagesStatus;
+
+      const typeCheck: ResultType extends ExpectedType ? true : false = true;
+      expect(typeCheck).toBe(true);
+    });
+
+    test('should narrow to RPCSPEC09.L1L2MessagesStatus when using v0.9.0', async () => {
+      type ResultType = Awaited<
+        ReturnType<typeof provider.getL1MessagesStatus<typeof constants.SupportedRpcVersion.v0_9_0>>
+      >;
+      type ExpectedType = RPCSPEC09.L1L2MessagesStatus;
+
+      const typeCheck: ResultType extends ExpectedType ? true : false = true;
+      expect(typeCheck).toBe(true);
+    });
+
+    test('should return union type when no version specified', async () => {
+      type ResultType = Awaited<ReturnType<typeof provider.getL1MessagesStatus>>;
+      type ExpectedType = RPCSPEC010.L1L2MessagesStatus | RPCSPEC09.L1L2MessagesStatus;
+
+      const typeCheck: ResultType extends ExpectedType ? true : false = true;
+      expect(typeCheck).toBe(true);
+    });
+  });
+
+  describe('Literal string type narrowing', () => {
+    test('should work with literal "0.10.0" for getEvents', async () => {
+      // Mock the getEvents method to avoid actual API calls
+      const mockEventsChunk: RPCSPEC010.EVENTS_CHUNK = {
+        events: [],
+        continuation_token: undefined,
+      };
+      jest.spyOn(provider, 'getEvents').mockResolvedValueOnce(mockEventsChunk);
+
+      const filter: RPCSPEC010.EventFilter = {
+        from_block: { block_number: 0 },
+        to_block: { block_number: 10 },
+        chunk_size: 10,
+      };
+
+      const result = await provider.getEvents<'0.10.0'>(filter);
+
+      const typeCheck: RPCSPEC010.EVENTS_CHUNK = result;
+      expect(typeCheck).toBeDefined();
+    });
+
+    test('should work with literal "0.9.0" for getEvents', async () => {
+      // Mock the getEvents method to avoid actual API calls
+      const mockEventsChunk: RPCSPEC09.EVENTS_CHUNK = {
+        events: [],
+        continuation_token: undefined,
+      };
+      jest.spyOn(provider, 'getEvents').mockResolvedValueOnce(mockEventsChunk);
+
+      const filter: RPCSPEC09.EventFilter = {
+        from_block: { block_number: 0 },
+        to_block: { block_number: 10 },
+        chunk_size: 10,
+      };
+
+      const result = await provider.getEvents<'0.9.0'>(filter);
+
+      const typeCheck: RPCSPEC09.EVENTS_CHUNK = result;
+      expect(typeCheck).toBeDefined();
+    });
+  });
+
+  afterEach(() => {
+    // Restore all mocks after each test
+    jest.restoreAllMocks();
+  });
+});

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -293,6 +293,12 @@ export class RpcProvider implements ProviderInterface {
     return createTransactionReceipt(txReceiptWoHelperModified);
   }
 
+  public async getTransactionTrace<V extends SupportedRpcVersion = SupportedRpcVersion>(
+    txHash: BigNumberish
+  ): Promise<V extends '0.10.0' ? RPCSPEC010.TRANSACTION_TRACE : RPCSPEC09.TRANSACTION_TRACE>;
+  public async getTransactionTrace(
+    txHash: BigNumberish
+  ): Promise<RPCSPEC010.TRANSACTION_TRACE | RPCSPEC09.TRANSACTION_TRACE>;
   public async getTransactionTrace(
     txHash: BigNumberish
   ): Promise<RPCSPEC010.TRANSACTION_TRACE | RPCSPEC09.TRANSACTION_TRACE> {
@@ -495,6 +501,14 @@ export class RpcProvider implements ProviderInterface {
     return this.channel.callContract(call, blockIdentifier);
   }
 
+  public async estimateMessageFee<V extends SupportedRpcVersion = SupportedRpcVersion>(
+    message: RPCSPEC09.L1Message,
+    blockIdentifier?: BlockIdentifier
+  ): Promise<V extends '0.10.0' ? RPCSPEC010.FEE_ESTIMATE : RPCSPEC09.MESSAGE_FEE_ESTIMATE>;
+  public async estimateMessageFee(
+    message: RPCSPEC09.L1Message,
+    blockIdentifier?: BlockIdentifier
+  ): Promise<RPCSPEC010.FEE_ESTIMATE | RPCSPEC09.MESSAGE_FEE_ESTIMATE>;
   public async estimateMessageFee(
     message: RPCSPEC09.L1Message, // same as spec08.L1Message
     blockIdentifier?: BlockIdentifier
@@ -506,6 +520,12 @@ export class RpcProvider implements ProviderInterface {
     return this.channel.getSyncingStats();
   }
 
+  public async getEvents<V extends SupportedRpcVersion = SupportedRpcVersion>(
+    eventFilter: V extends '0.10.0' ? RPCSPEC010.EventFilter : RPCSPEC09.EventFilter
+  ): Promise<V extends '0.10.0' ? RPCSPEC010.EVENTS_CHUNK : RPCSPEC09.EVENTS_CHUNK>;
+  public async getEvents(
+    eventFilter: RPCSPEC010.EventFilter | RPCSPEC09.EventFilter
+  ): Promise<RPCSPEC010.EVENTS_CHUNK | RPCSPEC09.EVENTS_CHUNK>;
   public async getEvents(
     eventFilter: RPCSPEC010.EventFilter | RPCSPEC09.EventFilter
   ): Promise<RPCSPEC010.EVENTS_CHUNK | RPCSPEC09.EVENTS_CHUNK> {
@@ -584,6 +604,14 @@ export class RpcProvider implements ProviderInterface {
     return bulk;
   }
 
+  public async getL1MessagesStatus<V extends SupportedRpcVersion = SupportedRpcVersion>(
+    transactionHash: BigNumberish
+  ): Promise<
+    V extends '0.10.0' ? RPC.RPCSPEC010.L1L2MessagesStatus : RPC.RPCSPEC09.L1L2MessagesStatus
+  >;
+  public async getL1MessagesStatus(
+    transactionHash: BigNumberish
+  ): Promise<RPC.RPCSPEC010.L1L2MessagesStatus | RPC.RPCSPEC09.L1L2MessagesStatus>;
   public async getL1MessagesStatus(
     transactionHash: BigNumberish
   ): Promise<RPC.RPCSPEC010.L1L2MessagesStatus | RPC.RPCSPEC09.L1L2MessagesStatus> {


### PR DESCRIPTION
## Motivation and Resolution
Uncertainty on params and response type for union Provider methods
Instead of an explicit response, casting a user can now do an explicit expected type

-optional type narrow: getEvents, getTransactionTrace, estimateMessageFee, getL1MessagesStatus

## Usage related changes
```ts
const result: RPCSPEC010.EVENTS_CHUNK = await provider.getEvents<typeof constants.SupportedRpcVersion.v0_10_0>(filter);
//or
const result: RPCSPEC010.EVENTS_CHUNK = await provider.getEvents<'0.10.0'>(filter);
```

I'm not convinced this is better than current type casting, but I'll let commenters decide.
One obvious advantage is that param is hard typed, so there is no option to pass false params. 

## Checklist:
- [ ] Performed a self-review of the code
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [ ] All tests are passing
