### PR TITLE
fix(contract): align invoke return types

### DIFF
--- a/src/contract/interface.ts
+++ b/src/contract/interface.ts
@@ -10,6 +10,7 @@ import type {
   InvokeFunctionResponse,
   PaymasterFeeEstimate,
   RawArgs,
+  SuccessfulTransactionReceiptResponseHelper,
   Uint256,
 } from '../types';
 import type {
@@ -42,7 +43,7 @@ declare module 'abi-wan-kanabi' {
     Calldata: RawArgs | Calldata;
     CallOptions: CallOptions;
     InvokeOptions: ExecuteOptions;
-    InvokeFunctionResponse: InvokeFunctionResponse;
+    InvokeFunctionResponse: InvokeFunctionResponse | SuccessfulTransactionReceiptResponseHelper;
   }
 }
 
@@ -169,6 +170,16 @@ export abstract class ContractInterface {
    * const receipt = await provider.waitForTransaction(tx.transaction_hash);
    * ```
    */
+  public abstract invoke(
+    method: string,
+    args: ArgsOrCalldata,
+    options: ExecuteOptions & { waitForTransaction: true }
+  ): Promise<SuccessfulTransactionReceiptResponseHelper>;
+  public abstract invoke(
+    method: string,
+    args: ArgsOrCalldata,
+    options: ExecuteOptions & { waitForTransaction: false }
+  ): Promise<InvokeFunctionResponse>;
   public abstract invoke(
     method: string,
     args?: ArgsOrCalldata,


### PR DESCRIPTION
## Motivation and Resolution

The Contract interface and typed ABI config did not expose the receipt return type for invoke when waitForTransaction: true, which diverged from runtime behavior. This updates the public typings to match the actual return values.

## Usage related changes

- ContractInterface.invoke now exposes overloads for waitForTransaction: true/false to reflect receipt vs hash return types.
- Typed ABI invoke responses can now include SuccessfulTransactionReceiptResponseHelper.

## Development related changes

- Type definitions for contract invoke are now aligned with implementation behavior.

## Checklist:

- [x] Performed a self-review of the code
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [x] All tests are passing
