### PR TITLE
fix: iffe shim plugin skip packing fs and path

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,9 +1,40 @@
-import { defineConfig } from 'tsup';
+import { defineConfig, Options } from 'tsup';
+import type { Plugin } from 'esbuild';
 
-export default defineConfig({
-  entry: ['src/index.ts'],
-  sourcemap: true,
-  clean: true,
-  format: ['cjs'],
-  globalName: 'starknet',
+/**
+ * Plugin to shim Node.js built-in modules (fs, path) for browser builds.
+ * Returns undefined for these modules, allowing runtime checks to handle the fallback.
+ */
+const browserNodeShimPlugin: Plugin = {
+  name: 'browser-node-shim',
+  setup(build) {
+    build.onResolve({ filter: /^(fs|path)$/ }, (args) => ({
+      path: args.path,
+      namespace: 'browser-node-shim',
+    }));
+    build.onLoad({ filter: /.*/, namespace: 'browser-node-shim' }, () => ({
+      contents: 'module.exports = undefined;',
+      loader: 'js',
+    }));
+  },
+};
+
+export default defineConfig((overrideOptions) => {
+  const baseConfig: Options = {
+    entry: ['src/index.ts'],
+    sourcemap: true,
+    clean: true,
+    format: ['cjs'],
+    globalName: 'starknet',
+  };
+
+  // For IIFE browser builds, add the shim plugin to handle Node.js modules
+  if (overrideOptions.format?.includes('iife')) {
+    return {
+      ...baseConfig,
+      esbuildPlugins: [browserNodeShimPlugin],
+    };
+  }
+
+  return baseConfig;
 });


### PR DESCRIPTION
## Motivation and Resolution

Problem: The IIFE browser build was failing because esbuild tried to bundle fs and path (Node.js built-in modules) even though the code has runtime checks to avoid using them in browsers.

Solution: tsup.config.ts to include an esbuild plugin that shims these Node.js modules for browser builds:

Created a browserNodeShimPlugin that intercepts require('fs') and require('path') calls
Returns undefined for these modules in browser builds
Conditionally applies the plugin only for IIFE format builds
This allows:
Node.js builds (CJS/ESM): Use real fs and path modules normally
Browser builds (IIFE): The modules return undefined, and your existing isFileSystemAvailable() runtime check gracefully handles this by directing users to use the File API instead

## Checklist:

- [ ] Performed a self-review of the code
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [ ] All tests are passing
