### PR TITLE
chore: improvement of UX for crypto function

### DIFF
--- a/__tests__/utils/stark.test.ts
+++ b/__tests__/utils/stark.test.ts
@@ -10,7 +10,6 @@ import {
   ArraySignatureType,
 } from '../../src';
 import sampleContract from '../../__mocks__/cairo/helloCairo2/C1v2.sierra.json';
-import { isHex } from '../../src/utils/num';
 
 const { toBigInt, toHex } = num;
 
@@ -213,8 +212,17 @@ describe('stark', () => {
       // User A is sending its pubK to user B.
       // user B is calculating the secret
       const sharedSecretB = stark.getSharedSecret(userBPrivK, userAFullPubK);
-      expect(isHex(sharedSecretA)).toBe(true);
+      expect(num.isHex(sharedSecretA)).toBe(true);
       expect(sharedSecretA).toBe(sharedSecretB);
+    });
+    test('wrong cases', () => {
+      expect(() => stark.getSharedSecret('0x123', '0x456')).toThrow();
+      expect(() =>
+        stark.getSharedSecret(
+          '0x123',
+          '0x0302d6b3ff569186d67a2ff0b8548328798d3500c16191f6c021f929134d48a15405f9fc5a11467b96a59b8fce3c0c919c337f11337c815bb9d0dc42bac7ac42a9'
+        )
+      ).toThrow();
     });
   });
 

--- a/__tests__/utils/stark.test.ts
+++ b/__tests__/utils/stark.test.ts
@@ -10,6 +10,7 @@ import {
   ArraySignatureType,
 } from '../../src';
 import sampleContract from '../../__mocks__/cairo/helloCairo2/C1v2.sierra.json';
+import { isHex } from '../../src/utils/num';
 
 const { toBigInt, toHex } = num;
 
@@ -197,6 +198,23 @@ describe('stark', () => {
           '0x9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba',
         ]);
       });
+    });
+  });
+
+  describe('getSharedSecret', () => {
+    test('derives shared secret from private key and public key', () => {
+      const userAPrivK = stark.randomAddress();
+      const userAFullPubK = stark.getFullPublicKey(userAPrivK);
+      const userBPrivK = stark.randomAddress();
+      const userBFullPubK = stark.getFullPublicKey(userBPrivK);
+      // User B is sending its pubK to user A.
+      // user A is calculating the secret
+      const sharedSecretA = stark.getSharedSecret(userAPrivK, userBFullPubK);
+      // User A is sending its pubK to user B.
+      // user B is calculating the secret
+      const sharedSecretB = stark.getSharedSecret(userBPrivK, userAFullPubK);
+      expect(isHex(sharedSecretA)).toBe(true);
+      expect(sharedSecretA).toBe(sharedSecretB);
     });
   });
 

--- a/src/utils/responseParser/rpc.ts
+++ b/src/utils/responseParser/rpc.ts
@@ -23,18 +23,15 @@ import {
 } from '../../provider/types/spec.type';
 // import { TransactionReceipt } from '../../types/api/merge';
 
-export class RPCResponseParser
-  implements
-    Omit<
-      ResponseParser,
-      | 'parseDeclareContractResponse'
-      | 'parseDeployContractResponse'
-      | 'parseInvokeFunctionResponse'
-      | 'parseGetTransactionReceiptResponse'
-      | 'parseGetTransactionResponse'
-      | 'parseCallContractResponse'
-    >
-{
+export class RPCResponseParser implements Omit<
+  ResponseParser,
+  | 'parseDeclareContractResponse'
+  | 'parseDeployContractResponse'
+  | 'parseInvokeFunctionResponse'
+  | 'parseGetTransactionReceiptResponse'
+  | 'parseGetTransactionResponse'
+  | 'parseCallContractResponse'
+> {
   private resourceBoundsOverhead: RpcProviderOptions['resourceBoundsOverhead'];
 
   constructor(resourceBoundsOverhead?: RpcProviderOptions['resourceBoundsOverhead']) {

--- a/src/utils/stark/index.ts
+++ b/src/utils/stark/index.ts
@@ -25,13 +25,13 @@ import {
   atobUniversal,
   btoaUniversal,
   buf2hex,
+  removeHexPrefix,
 } from '../encode';
 import { parse, stringify } from '../json';
 import {
   addPercent,
   bigNumberishArrayToDecimalStringArray,
   bigNumberishArrayToHexadecimalStringArray,
-  toBigInt,
   toHex,
 } from '../num';
 import { isBigInt, isObject, isString } from '../typed';
@@ -191,8 +191,13 @@ export function signatureToHexArray(sig?: Signature): ArraySignatureType {
  */
 export function getSharedSecret(privateKey: BigNumberish, fullPublicKey: BigNumberish): string {
   const privK = toHex(privateKey);
-  const fullPubK = toBigInt(fullPublicKey).toString(16).padStart(130, '0');
-  const sharedSecret = buf2hex(starkCurve.getSharedSecret(privK, fullPubK));
+  const fullPubKHex = removeHexPrefix(toHex(fullPublicKey)).padStart(130, '0');
+  if (fullPubKHex.length !== 130 || !fullPubKHex.startsWith('04')) {
+    throw new Error(
+      'fullPublicKey must be an uncompressed public key (starting with 04, 65 bytes total)'
+    );
+  }
+  const sharedSecret = buf2hex(starkCurve.getSharedSecret(privK, fullPubKHex));
   return addHexPrefix(sharedSecret);
 }
 

--- a/src/utils/stark/index.ts
+++ b/src/utils/stark/index.ts
@@ -31,9 +31,11 @@ import {
   addPercent,
   bigNumberishArrayToDecimalStringArray,
   bigNumberishArrayToHexadecimalStringArray,
+  toBigInt,
   toHex,
 } from '../num';
 import { isBigInt, isObject, isString } from '../typed';
+import { starkCurve } from '../ec';
 
 type V3Details = Required<
   Pick<
@@ -172,6 +174,26 @@ export function signatureToDecimalArray(sig?: Signature): ArraySignatureType {
  */
 export function signatureToHexArray(sig?: Signature): ArraySignatureType {
   return bigNumberishArrayToHexadecimalStringArray(formatSignature(sig));
+}
+
+/**
+ * Calculate the shared secret using ECDH key agreement protocol with a given private key and a full public key.
+ * @param {BigNumberish} privateKey - a Starknet 252 bits private key.
+ * @param {BigNumberish} fullPublicKey - a 520 bit number, representing the full public key related to `privateKey`, which can be obtained by `getFullPublicKey` function. This number needs to start with '0x04' to indicate that it's a full public key, and the remaining 128 bytes represent the x and y coordinates of the public key point on the elliptic curve (64 bytes for x and 64 bytes for y).
+ * @returns {string} an hex string of a 256 bit number, representing the shared secret calculated by ECDH key agreement protocol using `privateKey` and `fullPublicKey`.
+ * @example
+ * ```typescript
+ * const myPrivateKey = "0x67d0bd238e266b6defbb1ad4de4cf1dde2dc55b3518596e0bae29e439165596";
+ * const bobFullPublicKey = "0x0402d6b3ff569186d67a2ff0b8548328798d3500c16191f6c021f929134d48a15405f9fc5a11467b96a59b8fce3c0c919c337f11337c815bb9d0dc42bac7ac42a9";
+ * const result = stark.getSharedSecret(myPrivateKey, bobFullPublicKey);
+ * // result = "0x020619d1a277a5bc51aac6ab0c22d97e414d4bee9711a2d0aa421997f5efd68bab"
+ * ```
+ */
+export function getSharedSecret(privateKey: BigNumberish, fullPublicKey: BigNumberish): string {
+  const privK = toHex(privateKey);
+  const fullPubK = toBigInt(fullPublicKey).toString(16).padStart(130, '0');
+  const sharedSecret = buf2hex(starkCurve.getSharedSecret(privK, fullPubK));
+  return addHexPrefix(sharedSecret);
 }
 
 /**

--- a/www/docs/guides/account/signature.md
+++ b/www/docs/guides/account/signature.md
@@ -24,6 +24,19 @@ const msgHash = hash.computeHashOnElements(message);
 const signature: WeierstrassSignatureType = ec.starkCurve.sign(msgHash, privateKey);
 ```
 
+:::info
+
+- The full public key is a hex number, where the first byte is `04`, followed by a 64 characters number representing the X coordinate, and finally a 64 characters number representing the Y coordinate.
+
+ex: `0x0400b730bd22358612b5a67f8ad52ce80f9e8e893639ade263537e6ef35852e5d3057795f6b090f7c6985ee143f798608a53b3659222c06693c630857a10a92acf`,
+
+> where `04` is indicating that it's a non compressed public key, `00b730bd22358612b5a67f8ad52ce80f9e8e893639ade263537e6ef35852e5d3` is the X coordinate, `057795f6b090f7c6985ee143f798608a53b3659222c06693c630857a10a92acf`
+> is the Y coordinate.
+
+- the Starknet public key stored in an account contract is including only the X coordinate. It's a felt252.
+
+:::
+
 Then you can send, by any means, to the recipient of the message:
 
 - the message.


### PR DESCRIPTION
## Motivation and Resolution
Following user feedback, 
- improvement of documentation, to explain in detail the difference between Starknet public key and full public key.
- creation of `stark.getSharedSecret()` to have user friendly inputs/output.

## Usage related changes
`stark.getSharedSecret()` accepts BigNumberishes as input and returns an Hex string. It's using internally  `ec.starkCurve.getSharedSecret()` that is using low level types.

## Development related changes
N/A

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
