### PR TITLE
Feat/remove default providers

### DIFF
--- a/__tests__/utils/__snapshots__/json.test.ts.snap
+++ b/__tests__/utils/__snapshots__/json.test.ts.snap
@@ -19,5 +19,3 @@ Object {
   "n3": 1.1,
 }
 `;
-
-exports[`JSON utility tests stringify 1`] = `"{\\"provider\\":{\\"responseParser\\":{},\\"baseUrl\\":\\"https://alpha4.starknet.io\\",\\"feederGatewayUrl\\":\\"https://alpha4.starknet.io/feeder_gateway\\",\\"gatewayUrl\\":\\"https://alpha4.starknet.io/gateway\\",\\"chainId\\":\\"0x534e5f474f45524c49\\",\\"blockIdentifier\\":\\"pending\\"}}"`;

--- a/__tests__/utils/json.test.ts
+++ b/__tests__/utils/json.test.ts
@@ -1,14 +1,13 @@
-import { defaultProvider } from '../../src';
-import { parse, parseAlwaysAsBig, stringify } from '../../src/utils/json';
+import { parse, parseAlwaysAsBig } from '../../src/utils/json';
 
 const bi = (x: bigint) => BigInt(Number.MAX_SAFE_INTEGER) + x;
 const objString = `{"constructor":"c","n0":${bi(0n)},"n1":${bi(1n)},"n2":12,"n3":1.1}`;
 
 describe('JSON utility tests', () => {
-  xtest('stringify', () => {
-    // Disabled due to random nodeUrl nad diff params for RPC
-    expect(stringify(defaultProvider)).toMatchSnapshot();
-  });
+  // xtest('stringify', () => {
+  //   // Disabled due to random nodeUrl nad diff params for RPC
+  //   expect(stringify(someProvider)).toMatchSnapshot();
+  // });
 
   test('parse', () => {
     const parsed: any = parse(objString);

--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -85,7 +85,7 @@ import { getExecuteCalldata } from '../utils/transaction/transaction';
 import { isString, isUndefined } from '../utils/typed';
 import { getMessageHash } from '../utils/typedData';
 import { type AccountInterface } from './interface';
-import { defaultPaymaster, type PaymasterInterface, PaymasterRpc } from '../paymaster';
+import { type PaymasterInterface, PaymasterRpc } from '../paymaster';
 import { assertPaymasterTransactionSafety } from '../utils/paymaster';
 import assert from '../utils/assert';
 import { defaultDeployer, Deployer } from '../deployer';
@@ -131,7 +131,7 @@ export class Account implements AccountInterface {
       this.cairoVersion = cairoVersion.toString() as CairoVersion;
     }
     this.transactionVersion = transactionVersion ?? config.get('transactionVersion');
-    this.paymaster = paymaster ? new PaymasterRpc(paymaster) : defaultPaymaster;
+    this.paymaster = paymaster ? new PaymasterRpc(paymaster) : new PaymasterRpc();
     this.deployer = options.deployer ?? defaultDeployer;
     this.defaultTipType = defaultTipType ?? config.get('defaultTipType');
 

--- a/src/channel/rpc_0_10_0.ts
+++ b/src/channel/rpc_0_10_0.ts
@@ -99,19 +99,11 @@ export class RpcChannel {
       waitMode,
     } = optionsOrProvider || {};
     if (Object.values(NetworkName).includes(nodeUrl as NetworkName)) {
-      this.nodeUrl = getDefaultNodeUrl(
-        nodeUrl as NetworkName,
-        optionsOrProvider?.default,
-        this.channelSpecVersion
-      );
+      this.nodeUrl = getDefaultNodeUrl(nodeUrl as NetworkName, this.channelSpecVersion);
     } else if (nodeUrl) {
       this.nodeUrl = nodeUrl;
     } else {
-      this.nodeUrl = getDefaultNodeUrl(
-        undefined,
-        optionsOrProvider?.default,
-        this.channelSpecVersion
-      );
+      this.nodeUrl = getDefaultNodeUrl(undefined, this.channelSpecVersion);
     }
     const channelDefaults = config.get('channelDefaults');
     this.baseFetch = baseFetch || config.get('fetch') || fetch;

--- a/src/channel/rpc_0_9_0.ts
+++ b/src/channel/rpc_0_9_0.ts
@@ -100,19 +100,11 @@ export class RpcChannel {
       waitMode,
     } = optionsOrProvider || {};
     if (Object.values(NetworkName).includes(nodeUrl as NetworkName)) {
-      this.nodeUrl = getDefaultNodeUrl(
-        nodeUrl as NetworkName,
-        optionsOrProvider?.default,
-        this.channelSpecVersion
-      );
+      this.nodeUrl = getDefaultNodeUrl(nodeUrl as NetworkName, this.channelSpecVersion);
     } else if (nodeUrl) {
       this.nodeUrl = nodeUrl;
     } else {
-      this.nodeUrl = getDefaultNodeUrl(
-        undefined,
-        optionsOrProvider?.default,
-        this.channelSpecVersion
-      );
+      this.nodeUrl = getDefaultNodeUrl(undefined, this.channelSpecVersion);
     }
     const channelDefaults = config.get('channelDefaults');
     this.baseFetch = baseFetch || config.get('fetch') || fetch;

--- a/src/contract/default.ts
+++ b/src/contract/default.ts
@@ -41,7 +41,7 @@ import {
 } from '../utils/events/index';
 import { ContractInterface } from './interface';
 import { logger } from '../global/logger';
-import { defaultProvider } from '../provider';
+import { RpcProvider } from '../provider/rpc';
 import { getCompiledCalldata } from '../utils/transaction';
 import { extractAbi, parseContract } from '../utils/provider';
 
@@ -113,13 +113,15 @@ export class Contract implements ContractInterface {
 
   address: string;
 
-  providerOrAccount: ProviderOrAccount;
+  providerOrAccount?: ProviderOrAccount;
 
   classHash?: string;
 
   parseRequest: boolean;
 
   parseResponse: boolean;
+
+  private defaultProvider?: ProviderInterface;
 
   private structs: { [name: string]: AbiStruct };
 
@@ -146,16 +148,45 @@ export class Contract implements ContractInterface {
    * @private
    */
   private get provider(): ProviderInterface {
+    if (!this.providerOrAccount) {
+      throw new Error(
+        'Contract is not connected to a provider or account. Provide one during construction or call an async method to auto-initialize.'
+      );
+    }
     return isAccount(this.providerOrAccount)
       ? this.providerOrAccount.provider
       : this.providerOrAccount;
   }
 
   /**
+   * Lazily initialize and cache the default provider with node version detection
+   * @private
+   */
+  private async ensureProvider(): Promise<ProviderInterface> {
+    // If we already initialized the default provider, return cached version
+    if (this.defaultProvider) {
+      return this.defaultProvider;
+    }
+
+    // If providerOrAccount is already set, initialize it if needed and use it
+    if (this.providerOrAccount) {
+      if (isAccount(this.providerOrAccount)) {
+        return this.providerOrAccount.provider;
+      }
+      return this.providerOrAccount;
+    }
+
+    // First use: create provider with proper node detection
+    this.defaultProvider = await RpcProvider.create();
+    this.providerOrAccount = this.defaultProvider;
+    return this.defaultProvider;
+  }
+
+  /**
    * @param options
    *  - abi: Abi of the contract object (required)
    *  - address: address to connect to (required)
-   *  - providerOrAccount?: Provider or Account to attach to (fallback to defaultProvider)
+   *  - providerOrAccount?: Provider or Account to attach to (optional, creates default RpcProvider on first use with auto node detection)
    *  - parseRequest?: compile and validate arguments (optional, default true)
    *  - parseResponse?: Parse elements of the response array and structuring them into response object (optional, default true)
    *  - parser?: Abi parser (optional, default createAbiParser(options.abi))
@@ -167,7 +198,7 @@ export class Contract implements ContractInterface {
     const parser = createAbiParser(options.abi, options.parsingStrategy);
     this.abi = parser.getLegacyFormat();
     this.address = options.address && options.address.toLowerCase();
-    this.providerOrAccount = options.providerOrAccount ?? defaultProvider;
+    this.providerOrAccount = options.providerOrAccount;
 
     // Optional params
     this.parseRequest = options.parseRequest ?? true;
@@ -244,7 +275,8 @@ export class Contract implements ContractInterface {
 
   public async isDeployed(): Promise<this> {
     try {
-      await this.provider.getClassHashAt(this.address);
+      const provider = await this.ensureProvider();
+      await provider.getClassHashAt(this.address);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       throw new Error(`Contract not deployed at address ${this.address}: ${errorMessage}`);
@@ -274,7 +306,8 @@ export class Contract implements ContractInterface {
       return args;
     });
 
-    return this.provider
+    const provider = await this.ensureProvider();
+    return provider
       .callContract(
         {
           contractAddress: this.address,
@@ -331,7 +364,10 @@ export class Contract implements ContractInterface {
       calldata,
       entrypoint: method,
     };
-    if (isAccount(this.providerOrAccount)) {
+    // Ensure provider is initialized
+    await this.ensureProvider();
+
+    if (isAccount(this.providerOrAccount!)) {
       if (restInvokeOptions.paymasterDetails) {
         const myCall: Call = {
           contractAddress: this.address,
@@ -348,7 +384,8 @@ export class Contract implements ContractInterface {
         ...restInvokeOptions,
       });
       if (waitForTransaction) {
-        const result2: GetTransactionReceiptResponse = await this.provider.waitForTransaction(
+        const provider = await this.ensureProvider();
+        const result2: GetTransactionReceiptResponse = await provider.waitForTransaction(
           result.transaction_hash
         );
         if (result2.isSuccess()) {
@@ -363,7 +400,8 @@ export class Contract implements ContractInterface {
       throw new Error(`Manual nonce is required when invoking a function without an account`);
     logger.warn(`Invoking ${method} without an account.`);
 
-    return this.provider.invokeFunction(
+    const provider = await this.ensureProvider();
+    return provider.invokeFunction(
       {
         ...invocation,
         signature,
@@ -386,7 +424,10 @@ export class Contract implements ContractInterface {
       this.callData.validate(ValidateType.INVOKE, method, args);
     }
     const invocation = this.populate(method, args);
-    if (isAccount(this.providerOrAccount)) {
+    // Ensure provider is initialized
+    await this.ensureProvider();
+
+    if (isAccount(this.providerOrAccount!)) {
       if (estimateDetails.paymasterDetails) {
         const myCall: Call = {
           contractAddress: this.address,
@@ -432,7 +473,8 @@ export class Contract implements ContractInterface {
   }
 
   public async getVersion() {
-    return this.provider.getContractVersion(this.address);
+    const provider = await this.ensureProvider();
+    return provider.getContractVersion(this.address);
   }
 
   public typedv2<TAbi extends AbiKanabi>(tAbi: TAbi): TypedContractV2<TAbi> {

--- a/src/contract/interface.ts
+++ b/src/contract/interface.ts
@@ -74,8 +74,9 @@ export abstract class ContractInterface {
 
   /**
    * Provider for read operations or Account for write operations
+   * Optional - a default RpcProvider will be created on first async operation if not provided
    */
-  public abstract providerOrAccount: ProviderOrAccount;
+  public abstract providerOrAccount?: ProviderOrAccount;
 
   /**
    * Optional contract class hash for optimization

--- a/src/contract/types/index.type.ts
+++ b/src/contract/types/index.type.ts
@@ -85,7 +85,7 @@ export type ContractOptions = {
   /**
    * Connect account to read and write methods
    * Connect provider to read methods
-   * @default defaultProvider
+   * @default creates a new RpcProvider if not provided
    */
   providerOrAccount?: ProviderOrAccount;
 

--- a/src/paymaster/index.ts
+++ b/src/paymaster/index.ts
@@ -1,6 +1,2 @@
-import { PaymasterRpc } from './rpc';
-
 export * from './rpc';
 export * from './interface';
-
-export const defaultPaymaster = new PaymasterRpc({ default: true });

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -1,9 +1,5 @@
-import { RpcProvider } from './rpc';
-
 export { RpcProvider as Provider } from './rpc'; // backward-compatibility
 export { LibraryError, RpcError } from '../utils/errors';
 export * from './interface';
 export * from './rpc';
 export * from './modules';
-
-export const defaultProvider = new RpcProvider({ default: true });

--- a/src/provider/types/configuration.type.ts
+++ b/src/provider/types/configuration.type.ts
@@ -22,7 +22,6 @@ export type RpcProviderOptions = {
   blockIdentifier?: BlockIdentifier;
   chainId?: StarknetChainId;
   specVersion?: SupportedRpcVersion;
-  default?: boolean;
   waitMode?: boolean;
   baseFetch?: WindowOrWorkerGlobalScope['fetch'];
   resourceBoundsOverhead?: ResourceBoundsOverhead | false;

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -121,23 +121,19 @@ export function extractAbi(contract: ContractClass): Abi {
 /**
  * Return randomly select available public node
  * @param {NetworkName} networkName NetworkName
- * @param {boolean} mute mute public node warning
  * @returns {string} default node url
  * @example
  * ```typescript
- * const result= provider.getDefaultNodeUrl(constants.NetworkName.SN_MAIN,false);
+ * const result= provider.getDefaultNodeUrl(constants.NetworkName.SN_MAIN);
  * // console : "Using default public node url, please provide nodeUrl in provider options!"
  * // result = "https://starknet-mainnet.public.blastapi.io/rpc/v0_9"
  * ```
  */
 export const getDefaultNodeUrl = (
   networkName?: NetworkName,
-  mute: boolean = false,
   rpcVersion?: SupportedRpcVersion
 ): string => {
-  if (!mute) {
-    logger.info('Using default public node url, please provide nodeUrl in provider options!');
-  }
+  logger.info('Using default public node url, please provide nodeUrl in provider options!');
   const rpcNodes = getDefaultNodes(rpcVersion ?? config.get('rpcVersion'));
 
   const nodes = rpcNodes[networkName ?? NetworkName.SN_SEPOLIA];

--- a/www/docs/guides/account/paymaster.md
+++ b/www/docs/guides/account/paymaster.md
@@ -34,10 +34,11 @@ See [SNIP-9 compatibility](./outsideExecution.md#check-snip-9-support)
 
 Paymaster service is provided by specific backends compatible with [SNIP-29](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-29.md).
 
-By default, a random service is selected in the list of available services:
+To use a Paymaster service:
 
 ```typescript
-const myPaymasterRpc = new PaymasterRpc({ default: true });
+// Create a new Paymaster instance (uses a random available service)
+const myPaymasterRpc = new PaymasterRpc();
 ```
 
 If you want a specific Paymaster service:
@@ -245,7 +246,7 @@ import { FC, useEffect, useState } from 'react';
 import { connect } from 'get-starknet'; // v4 only
 import { Account, PaymasterRpc, TokenData, WalletAccount } from 'starknet'; // v8+
 
-const paymasterRpc = new PaymasterRpc({ default: true });
+const paymasterRpc = new PaymasterRpc();
 
 const App: FC = () => {
   const [account, setAccount] = useState<Account>();

--- a/www/docs/guides/migrate.md
+++ b/www/docs/guides/migrate.md
@@ -18,20 +18,23 @@ If you encounter any missing changes, please let us know and we will update this
 4. **Compression Functions** - `compressProgram()` and `decompressProgram()` are now async
 5. **SimulateTransaction Response** - `SimulateTransactionOverheadResponse` changed from array to object
 6. **Provider fetch() Method** - Now `async` (low impact)
-7. **ts-mixer Removed** - No longer a dependency
+7. **Removed Global Singletons** - `defaultProvider` and `defaultPaymaster` removed, use `RpcProvider.create()` instead
+8. **ts-mixer Removed** - No longer a dependency
 
 ### Breaking Changes Summary
 
-| Change                                                           | Severity   | Impact                                               |
-| ---------------------------------------------------------------- | ---------- | ---------------------------------------------------- |
-| Account composition (`account.xyz()` → `account.provider.xyz()`) | **High**   | All provider method calls on Account must be updated |
-| Compression functions now async (`await compressProgram()`)      | **Medium** | Only if using compress/decompress functions directly |
-| Plugin class renames (`StarknetId` → `StarknetIdImpl`)           | **Medium** | Only affects direct imports of these classes         |
-| Plugin import paths (`extensions/` → `plugins/`)                 | **Medium** | Only affects direct imports                          |
-| `SimulateTransactionOverheadResponse` is now an object           | **Medium** | Must access `.simulated_transactions` for the array  |
-| `fetch()` is now `async`                                         | **Low**    | Already returned Promise, minimal impact             |
-| `ts-mixer` removed                                               | **Low**    | Only affects if you used it as transitive dependency |
-| `plugins: false` disables defaults                               | **Info**   | Behavioral change, intentional opt-out               |
+| Change                                                           | Severity   | Impact                                                   |
+| ---------------------------------------------------------------- | ---------- | -------------------------------------------------------- |
+| Account composition (`account.xyz()` → `account.provider.xyz()`) | **High**   | All provider method calls on Account must be updated     |
+| Removed `defaultProvider` and `defaultPaymaster` singletons      | **Medium** | Use `await RpcProvider.create()` or `new PaymasterRpc()` |
+| Removed `default` parameter from RPC options                     | **Low**    | Parameter was only used by removed singletons            |
+| Compression functions now async (`await compressProgram()`)      | **Medium** | Only if using compress/decompress functions directly     |
+| Plugin class renames (`StarknetId` → `StarknetIdImpl`)           | **Medium** | Only affects direct imports of these classes             |
+| Plugin import paths (`extensions/` → `plugins/`)                 | **Medium** | Only affects direct imports                              |
+| `SimulateTransactionOverheadResponse` is now an object           | **Medium** | Must access `.simulated_transactions` for the array      |
+| `fetch()` is now `async`                                         | **Low**    | Already returned Promise, minimal impact                 |
+| `ts-mixer` removed                                               | **Low**    | Only affects if you used it as transitive dependency     |
+| `plugins: false` disables defaults                               | **Info**   | Behavioral change, intentional opt-out                   |
 
 **Quick migration steps:**
 
@@ -143,7 +146,70 @@ account.getStarkName();
 account.getAddressFromStarkName('name.stark');
 ```
 
-## Breaking Change 2: Plugin System
+## Breaking Change 2: Removed Global Singletons
+
+### What Changed
+
+In v10, the global singleton exports `defaultProvider` and `defaultPaymaster` have been removed to promote explicit initialization and better resource management.
+
+**❌ v9 (no longer works):**
+
+```typescript
+import { defaultProvider, defaultPaymaster } from 'starknet';
+
+// These no longer exist
+const result = await defaultProvider.getBlock('latest');
+const tokens = await defaultPaymaster.getSupportedTokens();
+```
+
+**✅ v10:**
+
+```typescript
+// For Provider: Use RpcProvider.create() for automatic node version detection
+const myProvider = await RpcProvider.create();
+const myProvider = await RpcProvider.create({ nodeUrl: constants.NetworkName.SN_MAIN });
+
+// Or create manually if you know the RPC version
+const myProvider = new RpcProvider({ nodeUrl: '...' });
+
+// For Paymaster: Create a new instance
+const myPaymaster = new PaymasterRpc();
+const myPaymaster = new PaymasterRpc({ nodeUrl: 'https://sepolia.paymaster.avnu.fi' });
+
+// Usage
+const result = await myProvider.getBlock('latest');
+const tokens = await myPaymaster.getSupportedTokens();
+```
+
+### Why This Change?
+
+**Benefits:**
+
+- **No implicit global state** - Clearer resource management and easier testing
+- **Auto node detection** - `RpcProvider.create()` automatically detects the node's RPC version
+- **Explicit initialization** - Your code is more transparent about which provider instance you're using
+- **Better contracts** - No hidden provider creation for contracts that don't provide one
+
+### Contract Class Changes
+
+Contracts now auto-initialize a provider on first async method call if none is provided:
+
+```typescript
+// v9 - Used global defaultProvider implicitly
+const contract = new Contract({ abi, address });
+const result = await contract.call('balanceOf', [address]); // Used defaultProvider
+
+// v10 - Still works, but creates provider on first use
+const contract = new Contract({ abi, address });
+const result = await contract.call('balanceOf', [address]); // Creates provider via RpcProvider.create()
+
+// Better: Provide explicit provider
+const provider = await RpcProvider.create({ nodeUrl });
+const contract = new Contract({ abi, address, providerOrAccount: provider });
+const result = await contract.call('balanceOf', [address]);
+```
+
+## Breaking Change 4: Plugin System
 
 ### What Changed
 
@@ -228,7 +294,7 @@ const provider = new RpcProvider({
 
 For more details on creating and using plugins, see the [Plugin System Guide](./plugins.md).
 
-## Breaking Change 3: Provider fetch() Method
+## Breaking Change 5: Provider fetch() Method
 
 ### What Changed
 
@@ -268,7 +334,7 @@ const result = await provider.fetch('starknet_getBlockWithTxHashes', { block_id:
 provider.fetch('starknet_chainId').then((result) => console.log(result));
 ```
 
-## Breaking Change 4: Compression Functions Now Async
+## Breaking Change 6: Compression Functions Now Async
 
 ### What Changed
 
@@ -326,7 +392,7 @@ async function processContract(program) {
 }
 ```
 
-## Breaking Change 5: SimulateTransaction Response Structure
+## Breaking Change 7: SimulateTransaction Response Structure
 
 ### What Changed
 
@@ -387,7 +453,7 @@ const fee = simResult.simulated_transactions[0].overall_fee;
 const traces = simResult.simulated_transactions.map((s) => s.transaction_trace);
 ```
 
-## Breaking Change 6: ts-mixer Removed
+## Breaking Change 8: ts-mixer Removed
 
 ### What Changed
 

--- a/www/docs/guides/provider_instance.md
+++ b/www/docs/guides/provider_instance.md
@@ -110,6 +110,20 @@ const myProvider = new RpcProvider(); // Sepolia
 
 > When using this syntax, a random public node will be selected.
 
+:::info
+
+For automatic node version detection, use `RpcProvider.create()` instead of the constructor:
+
+```typescript
+// Automatically detects RPC version and configures the correct channel
+const defaultProvider = await RpcProvider.create();
+const defaultProvider = await RpcProvider.create({ nodeUrl: constants.NetworkName.SN_MAIN });
+```
+
+This approach queries the node to determine its RPC specification version and applies the appropriate configuration automatically. Note that this is slightly slower due to the additional network request.
+
+:::
+
 Using a specific `nodeUrl` is the better approach, as such nodes will have fewer limitations, their software will be more up to date, and they will be less congested.
 
 Some examples of `RpcProvider` instantiation to connect to RPC node providers:


### PR DESCRIPTION
## Motivation and Resolution                                                                                                                          

  | Aspect | Before | After |
  |--------|--------|-------|
  | **Global State** | ⚠️  Implicit singletons | ✅ No global state |
  | **Node Detection** | ❌ Only for defaults | ✅ Available for all providers |
  | **Initialization** | ❌ Hidden/automatic | ✅ Explicit and transparent |
  | **Testing** | ⚠️  Harder (globals) | ✅ Easier (isolated) |
  | **Resource Management** | ⚠️  Always allocated | ✅ On-demand |
  | **API Clarity** | ⚠️  Magic behavior | ✅ Clear intent |

## Usage related changes

  - ✅ Removed export const defaultProvider from provider module                                                                                       
  - ✅ Removed export const defaultPaymaster from paymaster module
  - ✅ Removed default?: boolean parameter from RpcProviderOptions
  - ✅ Removed mute parameter from getDefaultNodeUrl()
  - ✅ Implemented lazy async initialization in Contract class using RpcProvider.create()
  - ✅ Updated RPC 0.10.0 and 0.9.0 channels
  - ✅ Updated Account paymaster initialization

  Provider Guide (provider_instance.md)
  Paymaster Guide (paymaster.md)
  Migration Guide (migrate.md)

## Checklist:

- [ ] Performed a self-review of the code
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [ ] All tests are passing
