### PR TITLE
Tests error in integration sepolia

### DIFF
--- a/__tests__/rpcProvider.test.ts
+++ b/__tests__/rpcProvider.test.ts
@@ -34,6 +34,7 @@ import {
   BlockTag,
   logger,
   type GasPrices,
+  CairoBytes31,
 } from '../src';
 import { StarknetChainId } from '../src/global/constants';
 import { isBoolean } from '../src/utils/typed';
@@ -128,11 +129,11 @@ describeIfRpc('RPCProvider', () => {
     const chainId2 = await rpcProvider.getChainId();
     expect(fetchSpy.mock.calls.length).toBe(1);
     expect(chainId1).toBe(chainId2);
-    expect(
-      (Object.values(StarknetChainId) as string[]).push(
-        '0x534e5f494e544547524154494f4e5f5345504f4c4941' // integration-sepolia
-      )
-    ).toContain(chainId1);
+    const chainIds = [
+      ...Object.values(StarknetChainId),
+      new CairoBytes31('SN_INTEGRATION_SEPOLIA').toHexString(),
+    ] as const;
+    expect(chainIds).toContain(chainId1);
     fetchSpy.mockRestore();
   });
 

--- a/__tests__/rpcProvider.test.ts
+++ b/__tests__/rpcProvider.test.ts
@@ -128,7 +128,11 @@ describeIfRpc('RPCProvider', () => {
     const chainId2 = await rpcProvider.getChainId();
     expect(fetchSpy.mock.calls.length).toBe(1);
     expect(chainId1).toBe(chainId2);
-    expect(Object.values(StarknetChainId)).toContain(chainId1);
+    expect(
+      (Object.values(StarknetChainId) as string[]).push(
+        '0x534e5f494e544547524154494f4e5f5345504f4c4941' // integration-sepolia
+      )
+    ).toContain(chainId1);
     fetchSpy.mockRestore();
   });
 


### PR DESCRIPTION
## Motivation and Resolution
When you launch the test suite in Integration Sepolia network, we have an error in `getChainId()` test, because this chain is not natively supported.

## Usage related changes
None. Only about test suite

## Development related changes
Added this chain in authorized answers

## Checklist:
- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Updated the tests
- [x] All tests are passing --> not tested all the suite due to personal lack of STRK in Integration Sepolia
