### PR TITLE
fix(hash): fold invoke proofFacts into one poseidon element

### DIFF
--- a/__tests__/utils/transactionHash.test.ts
+++ b/__tests__/utils/transactionHash.test.ts
@@ -1,3 +1,5 @@
+import { poseidonHashMany } from '@scure/starknet';
+
 import { constants, hash, v2hash, v3hash } from '../../src';
 import { EDAMode } from '../../src/types/api';
 import { toHex } from '../../src/utils/num';
@@ -66,6 +68,29 @@ describe('TxV3 Invoke proofFacts Hash Tests', () => {
       proofFacts: ['0x2', '0x1'],
     });
     expect(hashWithProof2).not.toBe(hashWithProof1);
+  });
+
+  test('proofFacts are hashed as one additional poseidon element', () => {
+    const result = hash.calculateInvokeTransactionHash({
+      ...baseArgs,
+      proofFacts: ['0x1', '0x2'],
+    });
+
+    const expected = v3hash.calculateTransactionHashCommon(
+      constants.TransactionHashPrefix.INVOKE,
+      baseArgs.version,
+      baseArgs.senderAddress,
+      baseArgs.chainId,
+      baseArgs.nonce,
+      baseArgs.tip,
+      baseArgs.paymasterData,
+      baseArgs.nonceDataAvailabilityMode,
+      baseArgs.feeDataAvailabilityMode,
+      baseArgs.resourceBounds,
+      [poseidonHashMany([]), poseidonHashMany([0x11n, 0x26n]), poseidonHashMany([0x1n, 0x2n])]
+    );
+
+    expect(result).toBe(expected);
   });
 });
 

--- a/src/utils/hash/transactionHash/v3.ts
+++ b/src/utils/hash/transactionHash/v3.ts
@@ -185,6 +185,8 @@ export function calculateInvokeTransactionHash(
   paymasterData: BigNumberish[],
   proofFacts?: BigNumberish[]
 ): string {
+  const proofFactsAdditionalData = proofFacts?.length ? [poseidonHashMany(AToBI(proofFacts))] : [];
+
   return calculateTransactionHashCommon(
     TransactionHashPrefix.INVOKE,
     version,
@@ -199,7 +201,7 @@ export function calculateInvokeTransactionHash(
     [
       poseidonHashMany(AToBI(accountDeploymentData)),
       poseidonHashMany(AToBI(compiledCalldata)),
-      ...(proofFacts ? AToBI(proofFacts) : []),
+      ...proofFactsAdditionalData,
     ]
   );
 }


### PR DESCRIPTION
## Summary
- change V3 invoke tx hashing so non-empty `proofFacts` are folded into one `poseidonHashMany(proofFacts)` additional-data element
- keep the existing behavior for omitted or empty `proofFacts`
- add a regression test that locks in the new additional-data shape

## Why
Privacy-network validation currently rejects signatures produced by the beta branch native signing path because the tx hash treats `proofFacts` as raw appended felts. Folding them into one Poseidon element matches the behavior required by the privacy-network / StarkWare fork semantics.

Fixes #1601

## Validation
- `TEST_ACCOUNT_ADDRESS=0x041c9dbe8ab9b414fa0ec4d22b7a41d80a3911b77a2c9c819ce949faa5edb9f9 TEST_ACCOUNT_PRIVATE_KEY=0x254055e37555fd981daf35700e046e42980f4e041d7aaec4886c0c1a46a07 TEST_RPC_URL=http://34.170.198.113:9545/rpc/v0_10 npx jest -i __tests__/utils/transactionHash.test.ts`
- `npx eslint src/utils/hash/transactionHash/v3.ts __tests__/utils/transactionHash.test.ts`

## Notes
- My local checkout has unrelated uncommitted changes in other files (`src/account/default.ts`, `src/provider/modules/responseParser/rpc.ts`, `src/provider/rpc.ts`, `pnpm-lock.yaml`) that are not part of this PR.