### PR TITLE
fix: unexpected INFO message when create an Account without Paymaster

### DIFF
--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -129,7 +129,7 @@ export class Account implements AccountInterface {
       this.cairoVersion = cairoVersion.toString() as CairoVersion;
     }
     this.transactionVersion = transactionVersion ?? config.get('transactionVersion');
-    this.paymaster = paymaster ? new PaymasterRpc(paymaster) : new PaymasterRpc();
+    this.paymaster = paymaster ? new PaymasterRpc(paymaster) : new PaymasterRpc({ mute: true });
     this.deployer = options.deployer ?? defaultDeployer;
     this.defaultTipType = defaultTipType ?? config.get('defaultTipType');
 

--- a/src/paymaster/rpc.ts
+++ b/src/paymaster/rpc.ts
@@ -100,11 +100,11 @@ export class PaymasterRpc implements PaymasterInterface {
 
     const { nodeUrl, headers, baseFetch } = options || {};
     if (nodeUrl && Object.values(NetworkName).includes(nodeUrl as NetworkName)) {
-      this.nodeUrl = getDefaultPaymasterNodeUrl(nodeUrl as NetworkName, options?.default);
+      this.nodeUrl = getDefaultPaymasterNodeUrl(nodeUrl as NetworkName, options?.mute);
     } else if (nodeUrl) {
       this.nodeUrl = nodeUrl;
     } else {
-      this.nodeUrl = getDefaultPaymasterNodeUrl(undefined, options?.default);
+      this.nodeUrl = getDefaultPaymasterNodeUrl(undefined, options?.mute);
     }
     this.baseFetch = baseFetch ?? fetch;
     this.headers = { ...defaultOptions.headers, ...headers };

--- a/src/paymaster/types/configuration.type.ts
+++ b/src/paymaster/types/configuration.type.ts
@@ -4,7 +4,7 @@ export interface PaymasterOptions extends PaymasterRpcOptions {}
 
 export type PaymasterRpcOptions = {
   nodeUrl?: string | NetworkName;
-  default?: boolean;
   headers?: object;
   baseFetch?: WindowOrWorkerGlobalScope['fetch'];
+  mute?: boolean;
 };


### PR DESCRIPTION
## Motivation and Resolution
When creating an `Account` instance with :
```ts
const account0 = new Account({ provider: myProvider, address: accountAddress0, signer: privateKey0 });
```
(so, without paymaster option)

We have this log:
```
[2026-04-22T13:27:33.268Z] INFO: Using default public node url, please provide nodeUrl in provider options!
```
In fact, the Account constructor  is calling `new PaymasterRpc()` if no paymaster option. It generates this INFO message about default paymaster url

## Usage related changes
None

## Development related changes
- In the Paymaster constructor, the options includes now a new `mute?: boolean`option, that is used by the constructor of `Account`, to avoid the info message.
- In `PaymasterRpcOptions`, the `default` option is removed (useless).

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] All tests are passing
