### PR TITLE
[codex] Address high CodeQL findings

### DIFF
--- a/__tests__/utils/cairoDataTypes/CairoFixedArray.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoFixedArray.test.ts
@@ -22,6 +22,8 @@ describe('CairoFixedArray class test', () => {
     expect(CairoFixedArray.getFixedArrayType('[[core::integer::u32; 2]; 8]')).toBe(
       '[core::integer::u32; 2]'
     );
+    expect(CairoFixedArray.isTypeFixedArray('[[core::integer::u32; 2]; 8]')).toBe(true);
+    expect(CairoFixedArray.getFixedArraySize('[[core::integer::u32; 2]; 8]')).toBe(8);
     expect(() => CairoFixedArray.getFixedArrayType('[; 8]')).toThrow();
     expect(CairoFixedArray.isTypeFixedArray('[core::integer::u32; 8]')).toBe(true);
     expect(CairoFixedArray.isTypeFixedArray('[core::integer::u32;8]')).toBe(false);

--- a/__tests__/utils/cairoDataTypes/CairoFixedArray.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoFixedArray.test.ts
@@ -19,10 +19,14 @@ describe('CairoFixedArray class test', () => {
     expect(CairoFixedArray.getFixedArraySize('[core::integer::u32; 8]')).toBe(8);
     expect(() => CairoFixedArray.getFixedArraySize('[core::integer::u32; zorg]')).toThrow();
     expect(CairoFixedArray.getFixedArrayType('[core::integer::u32; 8]')).toBe('core::integer::u32');
+    expect(CairoFixedArray.getFixedArrayType('[[core::integer::u32; 2]; 8]')).toBe(
+      '[core::integer::u32; 2]'
+    );
     expect(() => CairoFixedArray.getFixedArrayType('[; 8]')).toThrow();
     expect(CairoFixedArray.isTypeFixedArray('[core::integer::u32; 8]')).toBe(true);
     expect(CairoFixedArray.isTypeFixedArray('[core::integer::u32;8]')).toBe(false);
     expect(CairoFixedArray.isTypeFixedArray('[core::integer::u32; zorg]')).toBe(false);
+    expect(CairoFixedArray.isTypeFixedArray(`[; ${'; '.repeat(10_000)}]`)).toBe(false);
   });
 
   test('prepare fixed array for CallData.compile()', () => {

--- a/__tests__/utils/calldata/cairo.test.ts
+++ b/__tests__/utils/calldata/cairo.test.ts
@@ -83,6 +83,7 @@ describe('isTypeTuple', () => {
 
   test('should return false if given type is not Tuple ', () => {
     expect(isTypeTuple('core::bool')).toEqual(false);
+    expect(isTypeTuple(`(${'('.repeat(10_000)}`)).toEqual(false);
   });
 });
 
@@ -94,6 +95,7 @@ describe('isTypeNamedTuple', () => {
 
   test('should return false if given type is not named Tuple ', () => {
     expect(isTypeNamedTuple('(felt, felt)')).toEqual(false);
+    expect(isTypeNamedTuple(`${'('.repeat(10_000)}:`)).toEqual(false);
   });
 });
 
@@ -244,6 +246,7 @@ describe('isCairo1Type', () => {
 describe('getArrayType', () => {
   test('should extract type from an array', () => {
     expect(getArrayType('felt*')).toEqual('felt');
+    expect(getArrayType('felt**')).toEqual('felt');
     expect(getArrayType('core::array::Array::<core::bool>')).toEqual('core::bool');
   });
 });

--- a/__tests__/utils/starknetId.test.ts
+++ b/__tests__/utils/starknetId.test.ts
@@ -63,4 +63,17 @@ describe('Should test StarknetId utils', () => {
     expect(isStarkDomain(`${'a'.repeat(49)}.stark`)).toBe(false);
     expect(isStarkDomain(`${'---.'.repeat(10_000)}.stark`)).toBe(false);
   });
+
+  test('Should validate StarknetId domain label boundaries', () => {
+    // exactly 48 chars — valid
+    expect(isStarkDomain(`${'a'.repeat(48)}.stark`)).toBe(true);
+    // subdomain label exactly 48 chars — valid
+    expect(isStarkDomain(`${'a'.repeat(48)}.example.stark`)).toBe(true);
+    // subdomain label 49 chars — invalid (uniform 48-char limit on all labels)
+    expect(isStarkDomain(`${'a'.repeat(49)}.example.stark`)).toBe(false);
+    // empty label from double dot — invalid
+    expect(isStarkDomain('a..stark')).toBe(false);
+    // no name before .stark — invalid
+    expect(isStarkDomain('.stark')).toBe(false);
+  });
 });

--- a/__tests__/utils/starknetId.test.ts
+++ b/__tests__/utils/starknetId.test.ts
@@ -1,5 +1,10 @@
 import { StarknetChainId } from '../../src/global/constants';
-import { getStarknetIdContract, useDecoded, useEncoded } from '../../src/utils/starknetId';
+import {
+  getStarknetIdContract,
+  isStarkDomain,
+  useDecoded,
+  useEncoded,
+} from '../../src/utils/starknetId';
 
 function randomWithSeed(seed: number) {
   const x = Math.sin(seed) * 10000;
@@ -48,5 +53,14 @@ describe('Should test StarknetId utils', () => {
     expect(getStarknetIdContract(StarknetChainId.SN_MAIN)).toBe(
       '0x6ac597f8116f886fa1c97a23fa4e08299975ecaf6b598873ca6792b9bbfb678'
     );
+  });
+
+  test('Should validate StarknetId domains without backtracking', () => {
+    expect(isStarkDomain('example.stark')).toBe(true);
+    expect(isStarkDomain('sub.example.stark')).toBe(true);
+    expect(isStarkDomain('invalid-domain')).toBe(false);
+    expect(isStarkDomain('UPPER.stark')).toBe(false);
+    expect(isStarkDomain(`${'a'.repeat(49)}.stark`)).toBe(false);
+    expect(isStarkDomain(`${'---.'.repeat(10_000)}.stark`)).toBe(false);
   });
 });

--- a/src/utils/cairoDataTypes/fixedArray.ts
+++ b/src/utils/cairoDataTypes/fixedArray.ts
@@ -11,6 +11,26 @@ export class CairoFixedArray {
    */
   public readonly arrayType: string;
 
+  private static parseFixedArrayType(type: string) {
+    if (!type.startsWith('[') || !type.endsWith(']')) {
+      return undefined;
+    }
+
+    const separator = type.lastIndexOf('; ');
+    const itemType = type.slice(1, separator);
+    const size = type.slice(separator + 2, -1);
+
+    if (
+      separator <= 1 ||
+      size.length === 0 ||
+      ![...size].every((char) => char >= '0' && char <= '9')
+    ) {
+      return undefined;
+    }
+
+    return { itemType, size };
+  }
+
   /**
    * Create an instance representing a Cairo fixed Array.
    * @param {any[]} content JS array representing a Cairo fixed array.
@@ -60,10 +80,10 @@ export class CairoFixedArray {
    * ```
    */
   static getFixedArraySize(type: string) {
-    const matchArray = type.match(/(?<=; )\d+(?=\])/);
-    if (matchArray === null)
+    const fixedArrayType = CairoFixedArray.parseFixedArrayType(type);
+    if (!fixedArrayType)
       throw new Error(`ABI type ${type} do not includes a valid number after ';' character.`);
-    return Number(matchArray[0]);
+    return Number(fixedArrayType.size);
   }
 
   /**
@@ -91,10 +111,9 @@ export class CairoFixedArray {
    * ```
    */
   static getFixedArrayType = (type: string) => {
-    const matchArray = type.match(/(?<=\[).+(?=;)/);
-    if (matchArray === null)
-      throw new Error(`ABI type ${type} do not includes a valid type of data.`);
-    return matchArray[0];
+    const fixedArrayType = CairoFixedArray.parseFixedArrayType(type);
+    if (!fixedArrayType) throw new Error(`ABI type ${type} do not includes a valid type of data.`);
+    return fixedArrayType.itemType;
   };
 
   /**
@@ -156,8 +175,6 @@ export class CairoFixedArray {
    * // result = true
    */
   static isTypeFixedArray(type: string) {
-    return (
-      /^\[.*;\s.*\]$/.test(type) && /(?<=\[).+(?=;)/.test(type) && /(?<=; )\d+(?=\])/.test(type)
-    );
+    return CairoFixedArray.parseFixedArrayType(type) !== undefined;
   }
 }

--- a/src/utils/calldata/cairo.ts
+++ b/src/utils/calldata/cairo.ts
@@ -48,14 +48,17 @@ export const isTypeArray = (type: string) =>
  * @param {string} type - The type to be checked.
  * @returns - `true` if the type is a tuple type, otherwise `false`.
  */
-export const isTypeTuple = (type: string) => /^\(.*\)$/i.test(type);
+export const isTypeTuple = (type: string) => type.startsWith('(') && type.endsWith(')');
 /**
  * Checks whether a given type is a named tuple.
  *
  * @param {string} type - The type to be checked.
  * @returns - True if the type is a named tuple, false otherwise.
  */
-export const isTypeNamedTuple = (type: string) => /\(.*\)/i.test(type) && type.includes(':');
+export const isTypeNamedTuple = (type: string) => {
+  const start = type.indexOf('(');
+  return start !== -1 && type.indexOf(')', start + 1) !== -1 && type.includes(':');
+};
 /**
  * Checks if a given type is a struct.
  *
@@ -158,7 +161,7 @@ export const isCairo1Type = (type: string) => type.includes('::');
 export const getArrayType = (type: string) => {
   return isCairo1Type(type)
     ? type.substring(type.indexOf('<') + 1, type.lastIndexOf('>'))
-    : type.replace('*', '');
+    : type.replaceAll('*', '');
 };
 
 /**

--- a/src/utils/calldata/responseParser.ts
+++ b/src/utils/calldata/responseParser.ts
@@ -299,7 +299,7 @@ export default function responseParser({
           parsedDataArr.push(
             parseResponseValue(
               responseIterator,
-              { name, type: output.type.replace('*', '') },
+              { name, type: output.type.replaceAll('*', '') },
               parser,
               structs,
               enums

--- a/src/utils/starknetId.ts
+++ b/src/utils/starknetId.ts
@@ -409,5 +409,23 @@ export function dynamicCallData(
  * ```
  */
 export function isStarkDomain(domain: string): boolean {
-  return /^(?:[a-z0-9-]{1,48}(?:[a-z0-9-]{1,48}[a-z0-9-])?\.)*[a-z0-9-]{1,48}\.stark$/.test(domain);
+  const starkSuffix = '.stark';
+  if (!domain.endsWith(starkSuffix)) {
+    return false;
+  }
+
+  const name = domain.slice(0, -starkSuffix.length);
+  if (name.length === 0) {
+    return false;
+  }
+
+  return name.split('.').every((label) => {
+    return (
+      label.length > 0 &&
+      label.length <= 48 &&
+      [...label].every((char) => {
+        return (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9') || char === '-';
+      })
+    );
+  });
 }


### PR DESCRIPTION
## Summary
- replace CodeQL-flagged regex checks with deterministic string parsing for tuple, fixed-array, and Starknet ID domain validation
- replace single-occurrence `*` removal with `replaceAll` in calldata array type handling
- add focused regression coverage for the flagged patterns

## Validation
- `npm run lint`
- `npm run ts:check`
- `npx jest -i --config "{\"transform\":{\"^.+\\\\.(t|j)sx?$\":\"@swc/jest\"},\"testMatch\":[\"**/__tests__/**/(*.)+(spec|test).[jt]s?(x)\"]}" __tests__/utils/calldata/cairo.test.ts __tests__/utils/cairoDataTypes/CairoFixedArray.test.ts __tests__/utils/starknetId.test.ts`

Note: the repo default Jest config requires a local Starknet devnet, so the focused unit test command bypasses global setup for these pure utility tests.