### PR TITLE
docs: correct current docs content

### DIFF
--- a/www/ApiTitle.md
+++ b/www/ApiTitle.md
@@ -1,6 +1,8 @@
-## Provider
+# Starknet.js API
 
-The Provider [**API**](./classes/Provider.md) allows you to interact with the Starknet network, without signing transactions or messages.
+## RpcProvider
+
+The RpcProvider [**API**](./classes/Provider.md) allows you to interact with the Starknet network, without signing transactions or messages.
 
 Typically, these are _read_ calls on the blockchain.
 
@@ -8,7 +10,7 @@ Guide is [**here**](../guides/provider_instance.md).
 
 ## Account
 
-Account extends <ins>[`Provider`](./classes/Provider)</ins> and inherits all of its methods.
+Account has a <ins>[`RpcProvider`](./classes/Provider.md)</ins> instance and delegates read methods through that provider.
 
 It also introduces new methods that allow Accounts to create and verify signatures with a custom <ins>[`Signer`](./classes/Signer)</ins>, declare and deploy Contracts and new Accounts.
 

--- a/www/ApiTitle.md
+++ b/www/ApiTitle.md
@@ -1,8 +1,6 @@
-# Starknet.js API
-
 ## RpcProvider
 
-The RpcProvider [**API**](./classes/Provider.md) allows you to interact with the Starknet network, without signing transactions or messages.
+The RpcProvider [**API**](./classes/Provider.md) (`Provider` is a backward-compatibility alias) allows you to interact with the Starknet network, without signing transactions or messages.
 
 Typically, these are _read_ calls on the blockchain.
 

--- a/www/docs/guides/account/outsideExecution.md
+++ b/www/docs/guides/account/outsideExecution.md
@@ -16,6 +16,24 @@ Outside execution refers to the ability to execute transactions on behalf of an 
 
 To enable outside execution, the account contract must implement the necessary validation logic to verify external signatures or permissions.
 
+## Check SNIP-9 support
+
+Before relying on outside execution (e.g. to use a Paymaster), confirm that the account contract implements the SNIP-9 interface. Use [`Account.getSnip9Version`](../../API/classes/Account.md#getsnip9version):
+
+```typescript
+import { Account, OutsideExecutionVersion } from 'starknet';
+
+const myAccount = new Account({ provider, address, signer });
+const version = await myAccount.getSnip9Version();
+
+if (version === OutsideExecutionVersion.UNSUPPORTED) {
+  throw new Error('Account is not SNIP-9 compatible');
+}
+// version is "V1" or "V2"
+```
+
+`getSnip9Version` returns `V2` if the account exposes the SNIP-9 V2 interface, `V1` for V1, or `UNSUPPORTED` otherwise.
+
 ## Basic concept
 
 Instead of using the account's private key, outside execution uses:

--- a/www/docs/guides/account/outsideExecution.md
+++ b/www/docs/guides/account/outsideExecution.md
@@ -29,10 +29,10 @@ const version = await myAccount.getSnip9Version();
 if (version === OutsideExecutionVersion.UNSUPPORTED) {
   throw new Error('Account is not SNIP-9 compatible');
 }
-// version is "V1" or "V2"
+// version is OutsideExecutionVersion.V1 ('1') or OutsideExecutionVersion.V2 ('2')
 ```
 
-`getSnip9Version` returns `V2` if the account exposes the SNIP-9 V2 interface, `V1` for V1, or `UNSUPPORTED` otherwise.
+`getSnip9Version` returns `OutsideExecutionVersion.V2`, `OutsideExecutionVersion.V1`, or `OutsideExecutionVersion.UNSUPPORTED`.
 
 ## Basic concept
 

--- a/www/docs/guides/account/walletAccount.md
+++ b/www/docs/guides/account/walletAccount.md
@@ -20,11 +20,11 @@ In your DAPP, you have to use the `get-starknet` library to select and interact 
 
 ![](./pictures/WalletAccountArchitecture.png)
 
-When retrieving information from Starknet, a `WalletAccount` instance will read directly from the blockchain. That is why at the initialization of a `WalletAccount` a [`Provider`](../../API/classes/Provider) instance is a required parameter, it will be used for all reading activities.
+When retrieving information from Starknet, a `WalletAccount` instance will read directly from the blockchain. That is why at the initialization of a `WalletAccount` a provider is a required parameter - either [`ProviderOptions`](../../API/interfaces/ProviderOptions) (e.g. `{ nodeUrl }`) or a [`ProviderInterface`](../../API/classes/ProviderInterface) instance such as `RpcProvider`. It will be used for all reading activities.
 
 ## With get-starknet v5
 
-When retrieving information from Starknet, a `WalletAccountV5` instance will read directly from the blockchain. That is why at the initialization of a `WalletAccountV5` a [`RpcProvider`](../API/classes/ProviderInterface) instance is a required parameter, it will be used for all reading activities.
+When retrieving information from Starknet, a `WalletAccountV5` instance will read directly from the blockchain. That is why at the initialization of a `WalletAccountV5` a provider is a required parameter - either [`ProviderOptions`](../../API/interfaces/ProviderOptions) (e.g. `{ nodeUrl }`) or a [`ProviderInterface`](../../API/classes/ProviderInterface) instance such as `RpcProvider`. It will be used for all reading activities.
 
 If you want to write to Starknet the `WalletAccountV5` will ask the wallet to sign and send the transaction using the Starknet Wallet API to communicate.
 


### PR DESCRIPTION
## Summary
- Correct the current API intro text for `RpcProvider` and `Account` provider delegation.
- Add the current Outside Execution SNIP-9 compatibility check.
- Clarify current `WalletAccount` provider options without touching frozen docs versions.

## Split from
Part 1 of the split from #1613: pure content correction.

## Validation
- `npm run typecheck` in `www`
- `npm run ts:check`
- `DOCS_BASE_URL=/starknet.js/ npm run build`
- `npm audit --omit=dev` in `www`
- `git diff --check`