### PR TITLE
fix: accept provider options in WalletAccountV5.connect

### DIFF
--- a/src/wallet/account.ts
+++ b/src/wallet/account.ts
@@ -174,7 +174,7 @@ export class WalletAccount extends Account {
   }
 
   static async connectSilent(
-    provider: ProviderInterface,
+    provider: ProviderOptions | ProviderInterface,
     walletProvider: StarknetWalletProvider,
     cairoVersion?: CairoVersion,
     paymaster?: PaymasterOptions | PaymasterInterface

--- a/src/wallet/accountV5.ts
+++ b/src/wallet/accountV5.ts
@@ -19,6 +19,7 @@ import {
   CompiledSierra,
   DeclareContractPayload,
   MultiDeployContractResponse,
+  ProviderOptions,
   TypedData,
   UniversalDeployerContractPayload,
   type PaymasterOptions,
@@ -159,7 +160,7 @@ export class WalletAccountV5 extends Account {
   }
 
   static async connect(
-    provider: ProviderInterface,
+    provider: ProviderOptions | ProviderInterface,
     walletProvider: WalletWithStarknetFeatures,
     cairoVersion?: CairoVersion,
     paymaster?: PaymasterOptions | PaymasterInterface,

--- a/src/wallet/accountV5.ts
+++ b/src/wallet/accountV5.ts
@@ -177,7 +177,7 @@ export class WalletAccountV5 extends Account {
   }
 
   static async connectSilent(
-    provider: ProviderInterface,
+    provider: ProviderOptions | ProviderInterface,
     walletProvider: WalletWithStarknetFeatures,
     cairoVersion?: CairoVersion,
     paymaster?: PaymasterOptions | PaymasterInterface


### PR DESCRIPTION
## Summary
- Broaden `WalletAccountV5.connect` to accept `ProviderOptions | ProviderInterface`.
- Align the static helper signature with `WalletAccountV5Options.provider` and the documented `{ nodeUrl }` usage.

## Stack
Part 2 of the split from #1613: code correction.

Base PR: #1614

## Validation
- `npm run typecheck` in `www`
- `npm run ts:check`
- `DOCS_BASE_URL=/starknet.js/ npm run build`
- `npm audit --omit=dev` in `www`
- `git diff --check`