### PR TITLE
fix: add validation to cairofelt to ensure numbers are valid felt252 …

### DIFF
--- a/__tests__/utils/cairoDataTypes/CairoFelt.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoFelt.test.ts
@@ -41,19 +41,19 @@ describe('CairoFelt function', () => {
 
   test('should properly handle large BigInt values', () => {
     // Examples of large BigInt values found in blockchain environments.
-    expect(
+    expect(() =>
       CairoFelt(
         BigInt('57896044618658097711785492504343953926634992332820282019728792003956564819967')
       )
-    ).toBe('57896044618658097711785492504343953926634992332820282019728792003956564819967');
+    ).toThrow(/out of felt252 range/);
     expect(CairoFelt(BigInt('1524157875019052100'))).toBe('1524157875019052100');
   });
 
   test('should properly handle large hex number strings', () => {
     // Examples of large hex number strings found in blockchain environments.
-    expect(CairoFelt('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141')).toBe(
-      '115792089237316195423570985008687907852837564279074904382605163141518161494337'
-    );
+    expect(() =>
+      CairoFelt('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141')
+    ).toThrow(/out of felt252 range/);
     expect(CairoFelt('0x10A')).toBe('266');
   });
 
@@ -81,12 +81,12 @@ describe('CairoFelt function', () => {
   });
 
   test('should correctly handle zero-prefixed and hexadecimal string numbers', () => {
-    expect(CairoFelt('00123')).toBe('00123');
+    expect(CairoFelt('00123')).toBe('123');
     expect(CairoFelt('0xFF')).toBe(BigInt('0xFF').toString());
   });
 
-  test('should properly handle smallest integer', () => {
-    expect(CairoFelt(Number.MIN_SAFE_INTEGER)).toBe('-9007199254740991');
+  test('should reject negative integers', () => {
+    expect(() => CairoFelt(Number.MIN_SAFE_INTEGER)).toThrow(/out of felt252 range/);
   });
 
   test('should properly handle largest integer', () => {
@@ -173,8 +173,8 @@ describe('CairoFelt function', () => {
     const overflowNumber = BigInt(
       '115792089237316195423570985008687907853269984665640564039457584007913129639936'
     );
-    // CairoFelt does not currently check for uint256 overflow.
-    expect(() => CairoFelt(overflowNumber)).not.toThrow(); // CHANGED
+    // CairoFelt now checks for felt252 overflow.
+    expect(() => CairoFelt(overflowNumber)).toThrow(/out of felt252 range/);
   });
 
   test('should reject non-hexadecimal strings and invalid hex formats', () => {
@@ -192,8 +192,7 @@ describe('CairoFelt function', () => {
   });
 
   test('should handle zero-prefixed numbers and hex correctly', () => {
-    // CairoFelt currently does not remove leading zeros. You may need to update 'CairoFelt' to strip leading zeros if you need it to.
-    expect(CairoFelt('00123')).not.toBe('123'); //
+    expect(CairoFelt('00123')).toBe('123');
 
     expect(CairoFelt('0x00000123')).toBe(BigInt('0x00000123').toString());
   });
@@ -207,11 +206,9 @@ describe('CairoFelt function', () => {
   });
 
   test('should properly handle edge numeric values and formats', () => {
-    expect(CairoFelt(Number.MIN_SAFE_INTEGER)).toBe('-9007199254740991');
     expect(CairoFelt(Number.MAX_SAFE_INTEGER)).toBe('9007199254740991');
 
-    // CairoFelt doesn't currently throw for numbers beyond the safe upper limit for JavaScript numbers (Number.MAX_SAFE_INTEGER + 1). Update CairoFelt if you want to enforce this rule.
-    expect(() => CairoFelt(9007199254740992n)).not.toThrow(); //
+    expect(() => CairoFelt(9007199254740992n)).not.toThrow();
 
     expect(CairoFelt('0x0')).toBe('0');
   });
@@ -226,10 +223,10 @@ describe('CairoFelt function', () => {
     expect(() => CairoFelt(validAddress)).not.toThrow();
   });
 
-  test('should properly handle string values within uint256 limit', () => {
+  test('should reject values outside felt252 range even if within uint256 limit', () => {
     const withinLimit =
       '115792089237316195423570985008687907853269984665640564039457584007913129639935'; // Inside the upper limit of a uint256
-    expect(() => CairoFelt(BigInt(withinLimit))).not.toThrow();
+    expect(() => CairoFelt(BigInt(withinLimit))).toThrow(/out of felt252 range/);
   });
 
   test('should handle Regular strings that can be converted', () => {

--- a/src/utils/cairoDataTypes/felt.ts
+++ b/src/utils/cairoDataTypes/felt.ts
@@ -16,46 +16,6 @@ import assert from '../assert';
 import { addCompiledFlag } from '../helpers';
 
 /**
- * @deprecated use the CairoFelt252 class instead, this one is limited to ASCII strings
- * Create felt Cairo type (cairo type helper)
- * @returns format: felt-string
- */
-export function CairoFelt(it: BigNumberish): string {
-  // BN or number
-  if (isBigInt(it) || Number.isInteger(it)) {
-    return it.toString();
-  }
-
-  // Handling strings
-  if (isString(it)) {
-    // Hex strings
-    if (isHex(it)) {
-      return BigInt(it).toString();
-    }
-    // Text strings that must be short
-    if (isText(it)) {
-      if (!isShortString(it)) {
-        throw new Error(
-          `${it} is a long string > 31 chars. Please split it into an array of short strings.`
-        );
-      }
-      // Assuming encodeShortString returns a hex representation of the string
-      return BigInt(encodeShortString(it)).toString();
-    }
-    // Whole numeric strings
-    if (isStringWholeNumber(it)) {
-      return it;
-    }
-  }
-  // bool to felt
-  if (isBoolean(it)) {
-    return `${+it}`;
-  }
-
-  throw new Error(`${it} can't be computed by felt()`);
-}
-
-/**
  * felt252 is the basic field element used in Cairo.
  * It corresponds to an integer in the range 0 ≤ x < P where P is a very large prime number currently equal to 2^251 + 17⋅2^192 + 1.
  * Any operation that uses felt252 will be computed modulo P.
@@ -111,6 +71,10 @@ export class CairoFelt252 {
     return addCompiledFlag([this.toHexString()]);
   }
 
+  static assertRange(val: bigint): void {
+    assert(val >= 0n && val < PRIME, `Value ${val} is out of felt252 range [0, ${PRIME})`);
+  }
+
   static validate(data: BigNumberish | boolean | unknown): void {
     assert(data !== null, 'null value is not allowed for felt252');
     assert(data !== undefined, 'undefined value is not allowed for felt252');
@@ -121,7 +85,7 @@ export class CairoFelt252 {
 
     const value = CairoFelt252.__processData(data as BigNumberish | boolean);
     const bn = uint8ArrayToBigInt(value);
-    assert(bn >= 0n && bn < PRIME, `Value ${value} is out of felt252 range [0, ${PRIME})`);
+    CairoFelt252.assertRange(bn);
   }
 
   static is(data: BigNumberish | boolean | unknown): boolean {
@@ -143,4 +107,50 @@ export class CairoFelt252 {
      */
     return new CairoFelt252(getNext(responseIterator));
   }
+}
+
+/**
+ * @deprecated use the CairoFelt252 class instead, this one is limited to ASCII strings
+ * Create felt Cairo type (cairo type helper)
+ * @returns format: felt-string
+ */
+export function CairoFelt(it: BigNumberish): string {
+  // BN or number
+  if (isBigInt(it) || Number.isInteger(it)) {
+    const val = BigInt(it);
+    CairoFelt252.assertRange(val);
+    return val.toString();
+  }
+
+  // Handling strings
+  if (isString(it)) {
+    // Hex strings
+    if (isHex(it)) {
+      const val = BigInt(it);
+      CairoFelt252.assertRange(val);
+      return val.toString();
+    }
+    // Text strings that must be short
+    if (isText(it)) {
+      if (!isShortString(it)) {
+        throw new Error(
+          `${it} is a long string > 31 chars. Please split it into an array of short strings.`
+        );
+      }
+      // Assuming encodeShortString returns a hex representation of the string
+      return BigInt(encodeShortString(it)).toString();
+    }
+    // Whole numeric strings
+    if (isStringWholeNumber(it)) {
+      const val = BigInt(it);
+      CairoFelt252.assertRange(val);
+      return val.toString();
+    }
+  }
+  // bool to felt
+  if (isBoolean(it)) {
+    return `${+it}`;
+  }
+
+  throw new Error(`${it} can't be computed by felt()`);
 }


### PR DESCRIPTION
## Motivation and Resolution

When using `CallData.compile()` without an ABI, passing a bigint larger than the felt252 prime (e.g. `UINT_256_MAX`) caused that value to be silently serialized via `felt(value)` as a single felt. Since the value doesn't fit in a felt252, the resulting payload was invalid and the RPC failed with a generic deserialization error like:

```
-32602: Invalid invoke transaction v3: expected hex string to be prefixed by '0x': undefined
```

This change adds range validation to the `CairoFelt()` function so that any numeric value (bigint, number, hex string, or whole number string) outside the felt252 range `[0, PRIME)` throws a clear client-side error immediately:

```
Value <val> is out of felt252 range [0, <PRIME>)
```

This aligns the deprecated `CairoFelt()` function with its successor `CairoFelt252`, which already performed this validation.

### RPC version (if applicable)

N/A

## Usage related changes

- `CallData.compile()` without ABI now throws a clear error when a leaf value exceeds the felt252 range, instead of producing invalid calldata that causes cryptic RPC errors.
- Direct calls to `cairo.felt()` or `CairoFelt()` with out-of-range values now throw immediately.

## Development related changes

- Updated `CairoFelt` tests to expect errors for values outside felt252 range.
- Added explicit test coverage for the case where a value is within `uint256` range but outside `felt252` range.

fixes https://github.com/starknet-io/starknet.js/issues/1584

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)\- [x] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
