### PR TITLE
fix: fix snip-12 u256 hash mismatch

### DIFF
--- a/__tests__/utils/typedData.test.ts
+++ b/__tests__/utils/typedData.test.ts
@@ -339,7 +339,7 @@ describe('typedData', () => {
 
     messageHash = getMessageHash(examplePresetTypes, exampleAddress);
     expect(messageHash).toMatchInlineSnapshot(
-      `"0x185b339d5c566a883561a88fb36da301051e2c0225deb325c91bb7aa2f3473a"`
+      `"0x16e540c07db37a545d639a19511fb28d0886786332a93c1e381d00aa30094f2"`
     );
 
     messageHash = getMessageHash(exampleEnum, exampleAddress);
@@ -356,6 +356,48 @@ describe('typedData', () => {
     expect(spyPoseidon).toHaveBeenCalled();
     spyPedersen.mockRestore();
     spyPoseidon.mockRestore();
+  });
+
+  test('should flatten u256 to match Cairo hash', () => {
+    const u256TypedData = {
+      types: {
+        StarknetDomain: [
+          { name: 'name', type: 'shortstring' },
+          { name: 'version', type: 'shortstring' },
+          { name: 'chainId', type: 'shortstring' },
+          { name: 'revision', type: 'shortstring' },
+        ],
+        SimpleStruct: [{ name: 'some_u256', type: 'u256' }],
+      },
+      primaryType: 'SimpleStruct',
+      domain: {
+        name: 'DappName',
+        version: '1',
+        chainId: 'SN_SEPOLIA',
+        revision: '1',
+      },
+      message: {
+        some_u256: {
+          low: 1000,
+          high: 0,
+        },
+      },
+    };
+
+    const typeHash = getTypeHash(u256TypedData.types, 'SimpleStruct', TypedDataRevision.ACTIVE);
+    expect(typeHash).toMatchInlineSnapshot(
+      `"0x36991bcf00d0c2ac546204827d8a5e9924e5495b1184866fb61407bc92f76d3"`
+    );
+
+    const structHash = getStructHash(
+      u256TypedData.types,
+      'SimpleStruct',
+      u256TypedData.message,
+      TypedDataRevision.ACTIVE
+    );
+    expect(structHash).toMatchInlineSnapshot(
+      `"0x163fd1c083b57a2c46420dad63029329de470d95ddd6738637dcc11bc3a5d7d"`
+    );
   });
 
   describe('should fail validation', () => {
@@ -377,6 +419,56 @@ describe('typedData', () => {
       { type: 'shortstring' },
     ])('out of bounds - $type', ({ type }) => {
       expect(() => getMessageHash(baseTypes(type), exampleAddress)).toThrow(RegExp(type));
+    });
+
+    test('out of bounds - u256 low', () => {
+      const u256TypedData = {
+        types: {
+          StarknetDomain: [
+            { name: 'name', type: 'shortstring' },
+            { name: 'version', type: 'shortstring' },
+            { name: 'chainId', type: 'shortstring' },
+            { name: 'revision', type: 'shortstring' },
+          ],
+          Example: [{ name: 'value', type: 'u256' }],
+        },
+        primaryType: 'Example',
+        domain: {
+          name: 'Test',
+          version: '1',
+          chainId: '1',
+          revision: '1',
+        },
+        message: {
+          value: { low: PRIME, high: 0 },
+        },
+      };
+      expect(() => getMessageHash(u256TypedData, exampleAddress)).toThrow(/u128/);
+    });
+
+    test('out of bounds - u256 high', () => {
+      const u256TypedData = {
+        types: {
+          StarknetDomain: [
+            { name: 'name', type: 'shortstring' },
+            { name: 'version', type: 'shortstring' },
+            { name: 'chainId', type: 'shortstring' },
+            { name: 'revision', type: 'shortstring' },
+          ],
+          Example: [{ name: 'value', type: 'u256' }],
+        },
+        primaryType: 'Example',
+        domain: {
+          name: 'Test',
+          version: '1',
+          chainId: '1',
+          revision: '1',
+        },
+        message: {
+          value: { low: 0, high: PRIME },
+        },
+      };
+      expect(() => getMessageHash(u256TypedData, exampleAddress)).toThrow(/u128/);
     });
   });
 

--- a/src/utils/typedData.ts
+++ b/src/utils/typedData.ts
@@ -332,34 +332,50 @@ export function getTypeHash(
  * // result1 = ['felt', '0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e']
  * ```
  */
-export function encodeValue(
+function encodeValues(
   types: TypedData['types'],
   type: string,
   data: unknown,
   ctx: Context = {},
   revision: Revision = Revision.LEGACY
-): [string, string] {
+): [string[], string[]] {
+  if (type === 'u256' && revision === Revision.ACTIVE) {
+    const value = data as { low: BigNumberish; high: BigNumberish };
+    assertRange(value.low, 'u128', RANGE_U128);
+    assertRange(value.high, 'u128', RANGE_U128);
+    return [
+      ['u128', 'u128'],
+      [getHex(value.low), getHex(value.high)],
+    ];
+  }
+
   if (types[type]) {
-    return [type, getStructHash(types, type, data as TypedData['message'], revision)];
+    return [[type], [getStructHash(types, type, data as TypedData['message'], revision)]];
   }
 
   if (revisionConfiguration[revision].presetTypes[type]) {
     return [
-      type,
-      getStructHash(
-        revisionConfiguration[revision].presetTypes,
-        type,
-        data as TypedData['message'],
-        revision
-      ),
+      [type],
+      [
+        getStructHash(
+          revisionConfiguration[revision].presetTypes,
+          type,
+          data as TypedData['message'],
+          revision
+        ),
+      ],
     ];
   }
 
   if (type.endsWith('*')) {
-    const hashes: string[] = (data as Array<TypedData['message']>).map(
-      (entry) => encodeValue(types, type.slice(0, -1), entry, undefined, revision)[1]
-    );
-    return [type, revisionConfiguration[revision].hashMethod(hashes)];
+    const hashes: string[] = (data as Array<TypedData['message']>).map((entry) => {
+      const [, values] = encodeValues(types, type.slice(0, -1), entry, undefined, revision);
+      if (values.length > 1) {
+        return revisionConfiguration[revision].hashMethod(values);
+      }
+      return values[0];
+    });
+    return [[type], [revisionConfiguration[revision].hashMethod(hashes)]];
   }
 
   switch (type) {
@@ -372,34 +388,43 @@ export function encodeValue(
         const variantType = enumType.find((t) => t.name === variantKey) as StarknetType;
         const variantIndex = enumType.indexOf(variantType);
 
-        const encodedSubtypes = variantType.type
+        const encodedSubtypes: string[] = [];
+        variantType.type
           .slice(1, -1)
           .split(',')
-          .map((subtype, index) => {
-            if (!subtype) return subtype;
+          .forEach((subtype, index) => {
+            if (!subtype) {
+              encodedSubtypes.push(subtype);
+              return;
+            }
             const subtypeData = (variantData as unknown[])[index];
-            return encodeValue(types, subtype, subtypeData, undefined, revision)[1];
+            const [, values] = encodeValues(types, subtype, subtypeData, undefined, revision);
+            encodedSubtypes.push(...values);
           });
         return [
-          type,
-          revisionConfiguration[revision].hashMethod([variantIndex, ...encodedSubtypes]),
+          [type],
+          [revisionConfiguration[revision].hashMethod([variantIndex, ...encodedSubtypes])],
         ];
       } // else fall through to default
-      return [type, getHex(data as string)];
+      return [[type], [getHex(data as string)]];
     }
     case 'merkletree': {
       const merkleTreeType = getMerkleTreeType(types, ctx);
       const structHashes: string[] = (data as Array<TypedData['message']>).map((struct) => {
-        return encodeValue(types, merkleTreeType, struct, undefined, revision)[1];
+        const [, values] = encodeValues(types, merkleTreeType, struct, undefined, revision);
+        if (values.length > 1) {
+          return revisionConfiguration[revision].hashMethod(values);
+        }
+        return values[0];
       });
       const { root } = new MerkleTree(
         structHashes as string[],
         revisionConfiguration[revision].hashMerkleMethod
       );
-      return ['felt', root];
+      return [['felt'], [root]];
     }
     case 'selector': {
-      return ['felt', prepareSelector(data as string)];
+      return [['felt'], [prepareSelector(data as string)]];
     }
     case 'string': {
       if (revision === Revision.ACTIVE) {
@@ -410,24 +435,24 @@ export function encodeValue(
           byteArray.pending_word,
           byteArray.pending_word_len,
         ];
-        return [type, revisionConfiguration[revision].hashMethod(elements)];
+        return [[type], [revisionConfiguration[revision].hashMethod(elements)]];
       } // else fall through to default
-      return [type, getHex(data as string)];
+      return [[type], [getHex(data as string)]];
     }
     case 'i128': {
       if (revision === Revision.ACTIVE) {
         const value = BigInt(data as string);
         assertRange(value, type, RANGE_I128);
-        return [type, getHex(value < 0n ? PRIME + value : value)];
+        return [[type], [getHex(value < 0n ? PRIME + value : value)]];
       } // else fall through to default
-      return [type, getHex(data as string)];
+      return [[type], [getHex(data as string)]];
     }
     case 'timestamp':
     case 'u128': {
       if (revision === Revision.ACTIVE) {
         assertRange(data, type, RANGE_U128);
       } // else fall through to default
-      return [type, getHex(data as string)];
+      return [[type], [getHex(data as string)]];
     }
     case 'felt':
     case 'shortstring': {
@@ -435,28 +460,42 @@ export function encodeValue(
       if (revision === Revision.ACTIVE) {
         assertRange(getHex(data as string), type, RANGE_FELT);
       } // else fall through to default
-      return [type, getHex(data as string)];
+      return [[type], [getHex(data as string)]];
     }
     case 'ClassHash':
     case 'ContractAddress': {
       if (revision === Revision.ACTIVE) {
         assertRange(data, type, RANGE_FELT);
       } // else fall through to default
-      return [type, getHex(data as string)];
+      return [[type], [getHex(data as string)]];
     }
     case 'bool': {
       if (revision === Revision.ACTIVE) {
         assert(isBoolean(data), `Type mismatch for ${type} ${data}`);
       } // else fall through to default
-      return [type, getHex(data as string)];
+      return [[type], [getHex(data as string)]];
     }
     default: {
       if (revision === Revision.ACTIVE) {
         throw new Error(`Unsupported type: ${type}`);
       }
-      return [type, getHex(data as string)];
+      return [[type], [getHex(data as string)]];
     }
   }
+}
+
+export function encodeValue(
+  types: TypedData['types'],
+  type: string,
+  data: unknown,
+  ctx: Context = {},
+  revision: Revision = Revision.LEGACY
+): [string, string] {
+  const [typesArr, valuesArr] = encodeValues(types, type, data, ctx, revision);
+  if (typesArr.length !== 1 || valuesArr.length !== 1) {
+    throw new Error(`Type '${type}' encodes to multiple values`);
+  }
+  return [typesArr[0], valuesArr[0]];
 }
 
 /**
@@ -488,11 +527,11 @@ export function encodeData<T extends TypedData>(
 
       const value = data[field.name as keyof T['message']];
       const ctx = { parent: type, key: field.name };
-      const [t, encodedValue] = encodeValue(types, field.type, value, ctx, revision);
+      const [fieldTypes, fieldValues] = encodeValues(types, field.type, value, ctx, revision);
 
       return [
-        [...ts, t],
-        [...vs, encodedValue],
+        [...ts, ...fieldTypes],
+        [...vs, ...fieldValues],
       ];
     },
     [['felt'], [getTypeHash(types, type, revision)]]


### PR DESCRIPTION
fixes #1464

## Motivation and Resolution

In SNIP-12 revision 1 (ACTIVE), `starknet.js` was computing the struct hash of `u256`-containing typed data by treating `u256` as a **nested struct** with its own type-hash prefix:

```
// OLD (incorrect)
structHash(u256) = poseidon([typeHash(u256), low, high])
```

However, in Cairo `u256` is a core language primitive whose built-in `Hash` trait simply flattens `low` and `high` directly into the parent hash state. When OpenZeppelin's SNIP-12 guide uses `update_with(*self)` on a struct containing `u256`, Cairo adds `low` and `high` as individual felts — **not** as a nested sub-hash. This caused off-chain signatures produced by starknet.js to fail on-chain verification.

We fixed this by introducing an internal `encodeValues` helper that allows a single field to expand into multiple encoded values. For `u256` in ACTIVE revision, we now return `['u128', 'u128']` / `[low, high]` directly, matching Cairo's behavior. The exported `encodeValue` function remains backward-compatible as a thin wrapper.

I also ran additional validation with https://gist.github.com/JoE11-y/19b8a02c29e2f6e029f3d3fb5945add3 and verified the reported issue was fixed.

Here are the results:

```
Cairo output
Chain ID: 0
Version: 0

Expected Type hash:  0x36991bcf00d0c2ac546204827d8a5e9924e5495b1184866fb61407bc92f76d3
Actual Type hash:    0x36991bcf00d0c2ac546204827d8a5e9924e5495b1184866fb61407bc92f76d3 ✅

Expected Struct Hash: 0x3bd5c51013c6a5d6870fcb918d4aa263da7c989ae9b87a27e70e9b62c8def63
Actual Struct Hash:   0x163fd1c083b57a2c46420dad63029329de470d95ddd6738637dcc11bc3a5d7d ✅ (matches fixed starknet.js)

Expected Message Hash: 0x506cb0d4fa139e1add1e9d756fa2bba5f930aea55534685ca9077ae52ce5afc
Actual Message Hash:   0x5200dc6d2e4c406ad9a4a3975c60c524a473cce24bba0c98a1505f15fc7e57
```

I verified that both hashes now match exactly between Cairo and the fixed starknet.js when using the same domain values:

```
Hash
Cairo
Fixed starknet.js
Struct Hash
0x163fd1c083b57a2c46420dad63029329de470d95ddd6738637dcc11bc3a5d7d
0x163fd1c083b57a2c46420dad63029329de470d95ddd6738637dcc11bc3a5d7d ✅
Message Hash
0x5200dc6d2e4c406ad9a4a3975c60c524a473cce24bba0c98a1505f15fc7e57
0x5200dc6d2e4c406ad9a4a3975c60c524a473cce24bba0c98a1505f15fc7e57 ✅
```

(The message hash alignment required using the same domain values as the Cairo test: chainId: 0, version: 1, revision: 1. The original JS gist used 'SN_SEPOLIA' / '1' / '1' which is why the message hash differed even after the struct fix.)


### RPC version (if applicable)

N/A — this is a pure client-side hashing fix.

---

## Usage related changes

- `u256` fields in SNIP-12 ACTIVE revision typed data now produce struct hashes that match Cairo's on-chain `Hash` implementation.
- `getMessageHash`, `getStructHash`, and `encodeData` all reflect this change automatically.
- The exported `encodeValue` function throws for `u256` (since it returns multiple values), but this was already an internal-only edge case; the main entry points work correctly.

---

## Development related changes

- Added an internal `encodeValues` helper returning `[string[], string[]]` to support multi-value field encodings (currently only `u256`).
- Updated `encodeData`, array (`*`), enum, and merkle-tree handling to use `encodeValues` and properly spread multi-value results.
- Added dedicated tests for `u256` struct hash correctness and `u256` out-of-bounds validation.
- Updated inline snapshot for `examplePresetTypes` message hash to reflect the new flattened encoding.

---

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
