### PR TITLE
test: solve pb of use of ETH token in tests

### DIFF
--- a/__tests__/rpcProvider.test.ts
+++ b/__tests__/rpcProvider.test.ts
@@ -8,6 +8,7 @@ import {
   describeIfRpc,
   describeIfTestnet,
   ETHtokenAddress,
+  STRKtokenAddress,
   getTestAccount,
   initializeMatcher,
   waitNextBlock,
@@ -316,7 +317,7 @@ describeIfRpc('RPCProvider', () => {
     beforeAll(async () => {
       // add a Tx to be sure to have at least one Tx in the last block
       const { transaction_hash } = await account.execute({
-        contractAddress: ETHtokenAddress,
+        contractAddress: STRKtokenAddress,
         entrypoint: 'transfer',
         calldata: {
           recipient: account.address,


### PR DESCRIPTION
## Motivation and Resolution
The beforeAll block in the 'RPC methods' describe group (__tests__/rpcProvider.test.ts) executed a self-transfer of ETH tokens in order to guarantee at least one transaction in the latest block. On networks where the test account holds no ETH (e.g. Sepolia integration runs), this caused a u256_sub Overflow revert inside the ETH contract, crashing the entire suite before any test could run.

The fix replaces the token used for that dummy transaction with STRK. STRK is present on every supported test environment (devnet pre-funded accounts, Sepolia accounts funded for fee payment), so the transfer succeeds regardless of the network under test.

The two other usages of ETHtokenAddress in the same file (lines 604 and 644) are already guarded by describeIfDevnet and are not affected.

## Usage related changes
No

## Development related changes
`__tests__/rpcProvider.test.ts`: the beforeAll of 'RPC methods' now transfers STRK instead of ETH, making the Sepolia integration run stable when the test account carries no ETH.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Updated the tests
- [x] All tests are passing
