### PR TITLE
test: response has changed  when sending a wrong proof

### DIFF
--- a/__tests__/proof.test.ts
+++ b/__tests__/proof.test.ts
@@ -64,7 +64,7 @@ describeIfTestnet('Proof in transaction', () => {
         account.execute(myCall2, { proof, proofFacts: wrongProofFacts })
       ).rejects.toMatchObject({
         message: expect.stringContaining(
-          'Expected first field to be 88314448135728 (PROOF_VERSION)'
+          'Expected first field to be 88314448135728 (PROOF0) or 88314448135729 (PROOF1)'
         ),
       });
     });


### PR DESCRIPTION
## Motivation and Resolution
The Sepolia Testnet sequencer updated its error message for invalid `proofFacts`: the `PROOF_VERSION` marker was renamed to `PROOF0`, and the sequencer now also accepts a `PROOF1` variant (`88314448135729`). The test expected the old string and was failing against the current Sepolia node.

The expected error string in `__tests__/proof.test.ts` (test `tx with wrong proofFacts.PROOF0_marker`) is updated to match the new message:

Expected first field to be 88314448135728 (PROOF0) or 88314448135729 (PROOF1)



### RPC version (if applicable)
N/A

## Usage related changes
- No API change.

## Development related changes
- Updated the expected error string in `__tests__/proof.test.ts` to reflect the new sequencer message on Sepolia Testnet.

## Checklist:

- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Updated the tests
- [x] All tests are passing