### PR TITLE
feat: rpc v0.10.3 rc0 handling

### DIFF
--- a/__tests__/providerNarrowing.test.ts
+++ b/__tests__/providerNarrowing.test.ts
@@ -1,5 +1,5 @@
 import { RpcProvider, constants } from '../src';
-import { RPCSPEC09, RPCSPEC0101 } from '../src/types/api';
+import { RPCSPEC09, RPCSPEC0103 } from '../src/types/api';
 
 describe('Provider Type Narrowing', () => {
   let provider: RpcProvider;
@@ -10,15 +10,15 @@ describe('Provider Type Narrowing', () => {
   });
 
   describe('getEvents', () => {
-    test('should narrow to RPCSPEC0101.EVENTS_CHUNK when using v0.10.0', async () => {
+    test('should narrow to RPCSPEC0103.EVENTS_CHUNK when using v0.10.0', async () => {
       // Mock the getEvents method to avoid actual API calls
-      const mockEventsChunk: RPCSPEC0101.EVENTS_CHUNK = {
+      const mockEventsChunk: RPCSPEC0103.EVENTS_CHUNK = {
         events: [],
         continuation_token: undefined,
       };
       jest.spyOn(provider, 'getEvents').mockResolvedValueOnce(mockEventsChunk);
 
-      const filter: RPCSPEC0101.EventFilter = {
+      const filter: RPCSPEC0103.EventFilter = {
         from_block: { block_number: 0 },
         to_block: { block_number: 10 },
         chunk_size: 10,
@@ -26,8 +26,8 @@ describe('Provider Type Narrowing', () => {
 
       const result = await provider.getEvents<typeof constants.SupportedRpcVersion.v0_10_0>(filter);
 
-      // Type assertion to verify the type is correctly narrowed to RPCSPEC0101.EVENTS_CHUNK
-      const typeCheck: RPCSPEC0101.EVENTS_CHUNK = result;
+      // Type assertion to verify the type is correctly narrowed to RPCSPEC0103.EVENTS_CHUNK
+      const typeCheck: RPCSPEC0103.EVENTS_CHUNK = result;
       expect(typeCheck).toBeDefined();
       expect('events' in result).toBe(true);
     });
@@ -56,13 +56,13 @@ describe('Provider Type Narrowing', () => {
 
     test('should return union type when no version specified', async () => {
       // Mock the getEvents method to avoid actual API calls
-      const mockEventsChunk: RPCSPEC0101.EVENTS_CHUNK | RPCSPEC09.EVENTS_CHUNK = {
+      const mockEventsChunk: RPCSPEC0103.EVENTS_CHUNK | RPCSPEC09.EVENTS_CHUNK = {
         events: [],
         continuation_token: undefined,
       };
       jest.spyOn(provider, 'getEvents').mockResolvedValueOnce(mockEventsChunk);
 
-      const filter: RPCSPEC0101.EventFilter | RPCSPEC09.EventFilter = {
+      const filter: RPCSPEC0103.EventFilter | RPCSPEC09.EventFilter = {
         from_block: { block_number: 0 },
         to_block: { block_number: 10 },
         chunk_size: 10,
@@ -70,22 +70,22 @@ describe('Provider Type Narrowing', () => {
 
       const result = await provider.getEvents(filter);
 
-      // Type is union: RPCSPEC0101.EVENTS_CHUNK | RPCSPEC09.EVENTS_CHUNK
-      const typeCheck: RPCSPEC0101.EVENTS_CHUNK | RPCSPEC09.EVENTS_CHUNK = result;
+      // Type is union: RPCSPEC0103.EVENTS_CHUNK | RPCSPEC09.EVENTS_CHUNK
+      const typeCheck: RPCSPEC0103.EVENTS_CHUNK | RPCSPEC09.EVENTS_CHUNK = result;
       expect(typeCheck).toBeDefined();
       expect('events' in result).toBe(true);
     });
   });
 
   describe('getTransactionTrace', () => {
-    test('should narrow to RPCSPEC0101.TRANSACTION_TRACE when using v0.10.0', async () => {
+    test('should narrow to RPCSPEC0103.TRANSACTION_TRACE when using v0.10.0', async () => {
       // This test verifies type narrowing at compile time
       type ResultType = Awaited<
         ReturnType<
           typeof provider.getTransactionTrace<typeof constants.SupportedRpcVersion.v0_10_0>
         >
       >;
-      type ExpectedType = RPCSPEC0101.TRANSACTION_TRACE;
+      type ExpectedType = RPCSPEC0103.TRANSACTION_TRACE;
 
       // Type-level assertion
       const typeCheck: ResultType extends ExpectedType ? true : false = true;
@@ -106,7 +106,7 @@ describe('Provider Type Narrowing', () => {
 
     test('should return union type when no version specified', async () => {
       type ResultType = Awaited<ReturnType<typeof provider.getTransactionTrace>>;
-      type ExpectedType = RPCSPEC0101.TRANSACTION_TRACE | RPCSPEC09.TRANSACTION_TRACE;
+      type ExpectedType = RPCSPEC0103.TRANSACTION_TRACE | RPCSPEC09.TRANSACTION_TRACE;
 
       // Type-level assertion - union type should be assignable to both directions
       const typeCheck: ResultType extends ExpectedType ? true : false = true;
@@ -115,11 +115,11 @@ describe('Provider Type Narrowing', () => {
   });
 
   describe('estimateMessageFee', () => {
-    test('should narrow to RPCSPEC0101.FEE_ESTIMATE when using v0.10.0', async () => {
+    test('should narrow to RPCSPEC0103.FEE_ESTIMATE when using v0.10.0', async () => {
       type ResultType = Awaited<
         ReturnType<typeof provider.estimateMessageFee<typeof constants.SupportedRpcVersion.v0_10_0>>
       >;
-      type ExpectedType = RPCSPEC0101.FEE_ESTIMATE;
+      type ExpectedType = RPCSPEC0103.FEE_ESTIMATE;
 
       const typeCheck: ResultType extends ExpectedType ? true : false = true;
       expect(typeCheck).toBe(true);
@@ -137,7 +137,7 @@ describe('Provider Type Narrowing', () => {
 
     test('should return union type when no version specified', async () => {
       type ResultType = Awaited<ReturnType<typeof provider.estimateMessageFee>>;
-      type ExpectedType = RPCSPEC0101.FEE_ESTIMATE | RPCSPEC09.MESSAGE_FEE_ESTIMATE;
+      type ExpectedType = RPCSPEC0103.FEE_ESTIMATE | RPCSPEC09.MESSAGE_FEE_ESTIMATE;
 
       const typeCheck: ResultType extends ExpectedType ? true : false = true;
       expect(typeCheck).toBe(true);
@@ -145,13 +145,13 @@ describe('Provider Type Narrowing', () => {
   });
 
   describe('getL1MessagesStatus', () => {
-    test('should narrow to RPCSPEC0101.L1L2MessagesStatus when using v0.10.0', async () => {
+    test('should narrow to RPCSPEC0103.L1L2MessagesStatus when using v0.10.0', async () => {
       type ResultType = Awaited<
         ReturnType<
           typeof provider.getL1MessagesStatus<typeof constants.SupportedRpcVersion.v0_10_0>
         >
       >;
-      type ExpectedType = RPCSPEC0101.L1L2MessagesStatus;
+      type ExpectedType = RPCSPEC0103.L1L2MessagesStatus;
 
       const typeCheck: ResultType extends ExpectedType ? true : false = true;
       expect(typeCheck).toBe(true);
@@ -169,7 +169,7 @@ describe('Provider Type Narrowing', () => {
 
     test('should return union type when no version specified', async () => {
       type ResultType = Awaited<ReturnType<typeof provider.getL1MessagesStatus>>;
-      type ExpectedType = RPCSPEC0101.L1L2MessagesStatus | RPCSPEC09.L1L2MessagesStatus;
+      type ExpectedType = RPCSPEC0103.L1L2MessagesStatus | RPCSPEC09.L1L2MessagesStatus;
 
       const typeCheck: ResultType extends ExpectedType ? true : false = true;
       expect(typeCheck).toBe(true);
@@ -179,13 +179,13 @@ describe('Provider Type Narrowing', () => {
   describe('Literal string type narrowing', () => {
     test('should work with literal "0.10.0" for getEvents', async () => {
       // Mock the getEvents method to avoid actual API calls
-      const mockEventsChunk: RPCSPEC0101.EVENTS_CHUNK = {
+      const mockEventsChunk: RPCSPEC0103.EVENTS_CHUNK = {
         events: [],
         continuation_token: undefined,
       };
       jest.spyOn(provider, 'getEvents').mockResolvedValueOnce(mockEventsChunk);
 
-      const filter: RPCSPEC0101.EventFilter = {
+      const filter: RPCSPEC0103.EventFilter = {
         from_block: { block_number: 0 },
         to_block: { block_number: 10 },
         chunk_size: 10,
@@ -193,7 +193,7 @@ describe('Provider Type Narrowing', () => {
 
       const result = await provider.getEvents<'0.10.0'>(filter);
 
-      const typeCheck: RPCSPEC0101.EVENTS_CHUNK = result;
+      const typeCheck: RPCSPEC0103.EVENTS_CHUNK = result;
       expect(typeCheck).toBeDefined();
     });
 

--- a/__tests__/rpcChannel010.test.ts
+++ b/__tests__/rpcChannel010.test.ts
@@ -1,4 +1,4 @@
-import { LibraryError, RPC0101, RpcError } from '../src';
+import { LibraryError, RPC0102, RpcError } from '../src';
 import {
   createBlockForDevnet,
   createTestProvider,
@@ -8,19 +8,19 @@ import {
 
 testIfRpc010('RpcChannel', () => {
   let nodeUrl: string;
-  let channel08: RPC0101.RpcChannel;
+  let channel08: RPC0102.RpcChannel;
   initializeMatcher(expect);
 
   beforeAll(async () => {
     nodeUrl = (await createTestProvider(false)).channel.nodeUrl;
-    channel08 = new RPC0101.RpcChannel({ nodeUrl });
+    channel08 = new RPC0102.RpcChannel({ nodeUrl });
 
     await createBlockForDevnet();
   });
 
   test('baseFetch override', async () => {
     const baseFetch = jest.fn();
-    const fetchChannel08 = new RPC0101.RpcChannel({ nodeUrl, baseFetch });
+    const fetchChannel08 = new RPC0102.RpcChannel({ nodeUrl, baseFetch });
     (fetchChannel08.fetch as any)();
     expect(baseFetch).toHaveBeenCalledTimes(1);
     baseFetch.mockClear();
@@ -59,7 +59,7 @@ testIfRpc010('RpcChannel', () => {
 });
 
 describe('UNIT TEST: RPC 0.10.1 Channel - New API features', () => {
-  let channel: RPC0101.RpcChannel;
+  let channel: RPC0102.RpcChannel;
   let fetchSpy: jest.SpyInstance;
 
   const mockJsonResponse = (result: any) => ({
@@ -67,7 +67,7 @@ describe('UNIT TEST: RPC 0.10.1 Channel - New API features', () => {
   });
 
   beforeAll(() => {
-    channel = new RPC0101.RpcChannel({ nodeUrl: 'http://localhost:5050/rpc' });
+    channel = new RPC0102.RpcChannel({ nodeUrl: 'http://localhost:5050/rpc' });
   });
 
   afterEach(() => {

--- a/__tests__/utils/errors.test.ts
+++ b/__tests__/utils/errors.test.ts
@@ -2,7 +2,7 @@ import { RPC, RpcError } from '../../src';
 
 describe('Error utility tests', () => {
   test('RpcError', () => {
-    const baseError: RPC.RPCSPEC0101.UNEXPECTED_ERROR = {
+    const baseError: RPC.RPCSPEC0103.UNEXPECTED_ERROR = {
       code: 63,
       message: 'An unexpected error occurred',
       data: 'data',

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@scure/starknet": "1.1.0",
         "@starknet-io/get-starknet-wallet-standard": "^5.0.0",
         "@starknet-io/starknet-types-0101": "npm:@starknet-io/types-js@0.10.2",
-        "@starknet-io/starknet-types-0103": "file:/D/Starknet/types-jsFork/types-js",
+        "@starknet-io/starknet-types-0103": "npm:@starknet-io/types-js@0.10.3-beta.1",
         "@starknet-io/starknet-types-09": "npm:@starknet-io/types-js@~0.9.2",
         "abi-wan-kanabi": "2.2.4",
         "lossless-json": "^4.2.0"
@@ -68,21 +68,6 @@
       },
       "engines": {
         "node": ">=22"
-      }
-    },
-    "../../Starknet/types-jsFork/types-js": {
-      "name": "@starknet-io/types-js",
-      "version": "0.10.3",
-      "license": "MIT",
-      "devDependencies": {
-        "@biomejs/biome": "^2.3.1",
-        "@semantic-release/changelog": "^6.0.3",
-        "@semantic-release/commit-analyzer": "^13.0.0",
-        "@semantic-release/git": "^10.0.1",
-        "@semantic-release/npm": "^13.1.1",
-        "@semantic-release/release-notes-generator": "^14.0.0",
-        "semantic-release": "^25.0.1",
-        "typescript": "^5.9.3"
       }
     },
     "node_modules/@actions/core": {
@@ -4641,8 +4626,11 @@
       "license": "MIT"
     },
     "node_modules/@starknet-io/starknet-types-0103": {
-      "resolved": "../../Starknet/types-jsFork/types-js",
-      "link": true
+      "name": "@starknet-io/types-js",
+      "version": "0.10.3-beta.1",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.3-beta.1.tgz",
+      "integrity": "sha512-MaTTU3GI35y/yLEoRZb1RNLrFTHl5ZkbaVe+P/CMJbaWLnA0olxlvugcjbFIAVFr7f2Q3P8FX5AUZBoIOojoVQ==",
+      "license": "MIT"
     },
     "node_modules/@starknet-io/starknet-types-09": {
       "name": "@starknet-io/types-js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@scure/starknet": "1.1.0",
         "@starknet-io/get-starknet-wallet-standard": "^5.0.0",
         "@starknet-io/starknet-types-0101": "npm:@starknet-io/types-js@0.10.2",
+        "@starknet-io/starknet-types-0103": "file:/D/Starknet/types-jsFork/types-js",
         "@starknet-io/starknet-types-09": "npm:@starknet-io/types-js@~0.9.2",
         "abi-wan-kanabi": "2.2.4",
         "lossless-json": "^4.2.0"
@@ -67,6 +68,21 @@
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "../../Starknet/types-jsFork/types-js": {
+      "name": "@starknet-io/types-js",
+      "version": "0.10.3",
+      "license": "MIT",
+      "devDependencies": {
+        "@biomejs/biome": "^2.3.1",
+        "@semantic-release/changelog": "^6.0.3",
+        "@semantic-release/commit-analyzer": "^13.0.0",
+        "@semantic-release/git": "^10.0.1",
+        "@semantic-release/npm": "^13.1.1",
+        "@semantic-release/release-notes-generator": "^14.0.0",
+        "semantic-release": "^25.0.1",
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@actions/core": {
@@ -166,7 +182,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1032,7 +1047,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1056,7 +1070,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3265,7 +3278,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -4628,6 +4640,10 @@
       "integrity": "sha512-AtUFPYdmo9DqVus++aBSoY9W13/2PZmillPr8/mXZjc+V0iYJ/QTmkTsbw+es2mnLeLhYWSymW9ivQzyyyKdog==",
       "license": "MIT"
     },
+    "node_modules/@starknet-io/starknet-types-0103": {
+      "resolved": "../../Starknet/types-jsFork/types-js",
+      "link": true
+    },
     "node_modules/@starknet-io/starknet-types-09": {
       "name": "@starknet-io/types-js",
       "version": "0.9.2",
@@ -4648,7 +4664,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.25"
@@ -5092,7 +5107,6 @@
       "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.10.0"
       }
@@ -5141,7 +5155,6 @@
       "integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "7.18.0",
@@ -5176,7 +5189,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -5683,7 +5695,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5744,7 +5755,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6309,7 +6319,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001737",
         "electron-to-chromium": "^1.5.211",
@@ -7239,7 +7248,6 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -8240,7 +8248,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -8305,7 +8312,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -8407,7 +8413,6 @@
       "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -8471,7 +8476,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -12694,7 +12698,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -13349,7 +13352,6 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -15626,7 +15628,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16586,7 +16587,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -17329,7 +17329,6 @@
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -19007,7 +19006,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -19173,7 +19171,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -19543,7 +19540,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20401,6 +20397,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "packages/get-starknet-wallet-standard-v6": {
+      "name": "@starknet-io/get-starknet-wallet-standard-v6",
+      "version": "6.0.0-stub",
+      "extraneous": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "@scure/starknet": "1.1.0",
     "@starknet-io/get-starknet-wallet-standard": "^5.0.0",
     "@starknet-io/starknet-types-0101": "npm:@starknet-io/types-js@0.10.2",
+    "@starknet-io/starknet-types-0103": "file:/D/Starknet/types-jsFork/types-js",
     "@starknet-io/starknet-types-09": "npm:@starknet-io/types-js@~0.9.2",
     "abi-wan-kanabi": "2.2.4",
     "lossless-json": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@scure/starknet": "1.1.0",
     "@starknet-io/get-starknet-wallet-standard": "^5.0.0",
     "@starknet-io/starknet-types-0101": "npm:@starknet-io/types-js@0.10.2",
-    "@starknet-io/starknet-types-0103": "file:/D/Starknet/types-jsFork/types-js",
+    "@starknet-io/starknet-types-0103": "npm:@starknet-io/types-js@0.10.3-beta.1",
     "@starknet-io/starknet-types-09": "npm:@starknet-io/types-js@~0.9.2",
     "abi-wan-kanabi": "2.2.4",
     "lossless-json": "^4.2.0"

--- a/src/channel/index.ts
+++ b/src/channel/index.ts
@@ -1,7 +1,8 @@
 export * as RPC09 from './rpc_0_9_0';
-export * as RPC0101 from './rpc_0_10_2';
+export * as RPC0102 from './rpc_0_10_2';
+export * as RPC0103 from './rpc_0_10_3';
 // Default channel
-export * from './rpc_0_10_2';
+export * from './rpc_0_10_3';
 export * from './ws/ws_0_10';
 export * from './ws/subscription';
 export { TimeoutError, WebSocketNotConnectedError } from '../utils/errors';

--- a/src/channel/rpc_0_10_2.ts
+++ b/src/channel/rpc_0_10_2.ts
@@ -1,3 +1,4 @@
+import * as RPC from '@starknet-io/starknet-types-0101';
 import {
   NetworkName,
   StarknetChainId,
@@ -22,7 +23,7 @@ import {
   waitForTransactionOptions,
 } from '../types';
 import assert from '../utils/assert';
-import { ETransactionType, JRPC, RPCSPEC0101 as RPC } from '../types/api';
+import { ETransactionType, JRPC } from '../types/api';
 import { BatchClient } from '../utils/batch';
 import { CallData } from '../utils/calldata';
 import { isSierra } from '../utils/contract';
@@ -51,7 +52,7 @@ import { logger } from '../global/logger';
 import { config } from '../global/config';
 
 export class RpcChannel {
-  readonly id = 'RPC0.10.2';
+  readonly id: string = 'RPC0.10.2';
 
   /**
    * RPC specification version this Channel class implements

--- a/src/channel/rpc_0_10_3.ts
+++ b/src/channel/rpc_0_10_3.ts
@@ -1,0 +1,8 @@
+import { SupportedRpcVersion } from '../global/constants';
+import { RpcChannel as RpcChannel_0_10_2 } from './rpc_0_10_2';
+
+export class RpcChannel extends RpcChannel_0_10_2 {
+  override readonly id = 'RPC0.10.3';
+
+  override readonly channelSpecVersion: SupportedRpcVersion = SupportedRpcVersion.v0_10_3;
+}

--- a/src/channel/ws/ws_0_10.ts
+++ b/src/channel/ws/ws_0_10.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 import {
   JRPC,
-  RPCSPEC0101,
+  RPCSPEC0103,
   StarknetEventsEvent,
   NewHeadsEvent,
   TransactionsStatusEvent,
@@ -58,7 +58,7 @@ export interface SubscribeNewTransactionsParams {
   /** Filter by sender addresses */
   senderAddress?: BigNumberish[];
   /** Subscription tags for additional data (RPC 0.10.1+) */
-  tags?: RPCSPEC0101.SUBSCRIPTION_TAG[];
+  tags?: RPCSPEC0103.SUBSCRIPTION_TAG[];
 }
 
 // Subscription Result types

--- a/src/global/constants.ts
+++ b/src/global/constants.ts
@@ -104,9 +104,11 @@ const _SupportedRpcVersion = {
   '0.9.0': '0.9.0',
   '0.10.0': '0.10.0',
   '0.10.2': '0.10.2',
+  '0.10.3': '0.10.3',
   v0_9_0: '0.9.0',
   v0_10_0: '0.10.0',
   v0_10_2: '0.10.2',
+  v0_10_3: '0.10.3',
 } as const;
 type _SupportedRpcVersion = ValuesType<typeof _SupportedRpcVersion>;
 export { _SupportedRpcVersion as SupportedRpcVersion };
@@ -116,7 +118,8 @@ export { _SupportedRpcVersion as SupportedRpcVersion };
  */
 export type SupportedRpcVersion0_10 =
   | typeof _SupportedRpcVersion.v0_10_0
-  | typeof _SupportedRpcVersion.v0_10_2;
+  | typeof _SupportedRpcVersion.v0_10_2
+  | typeof _SupportedRpcVersion.v0_10_3;
 
 export type SupportedTransactionVersion = typeof ETransactionVersion.V3;
 export type SupportedCairoVersion = '1';

--- a/src/provider/interface.ts
+++ b/src/provider/interface.ts
@@ -1,4 +1,4 @@
-import { RPC09, RPC0101 } from '../channel';
+import { RPC09, RPC0102, RPC0103 } from '../channel';
 import { StarknetChainId } from '../global/constants';
 import type {
   AccountInvocations,
@@ -40,11 +40,11 @@ import type {
   StorageResponse,
 } from '../types';
 import { TipAnalysisOptions, TipEstimate } from './modules/tip';
-import { RPCSPEC09, RPCSPEC0101 } from '../types/api';
+import { RPCSPEC09, RPCSPEC0103 } from '../types/api';
 import { RPCResponseParser } from './modules/responseParser';
 
 export abstract class ProviderInterface {
-  public abstract channel: RPC09.RpcChannel | RPC0101.RpcChannel;
+  public abstract channel: RPC09.RpcChannel | RPC0102.RpcChannel | RPC0103.RpcChannel;
 
   public abstract responseParser: RPCResponseParser;
 
@@ -153,7 +153,7 @@ export abstract class ProviderInterface {
     contractAddress: BigNumberish,
     key: BigNumberish,
     blockIdentifier?: BlockIdentifier,
-    responseFlags?: RPCSPEC0101.STORAGE_RESPONSE_FLAG[]
+    responseFlags?: RPCSPEC0103.STORAGE_RESPONSE_FLAG[]
   ): Promise<StorageResponse>;
 
   /**
@@ -528,7 +528,7 @@ export abstract class ProviderInterface {
    */
   public abstract getTransactionTrace(
     txHash: BigNumberish
-  ): Promise<RPCSPEC0101.TRANSACTION_TRACE | RPCSPEC09.TRANSACTION_TRACE>;
+  ): Promise<RPCSPEC0103.TRANSACTION_TRACE | RPCSPEC09.TRANSACTION_TRACE>;
 
   /**
    * Get the status of a transaction
@@ -586,7 +586,7 @@ export abstract class ProviderInterface {
   public abstract estimateMessageFee(
     message: RPCSPEC09.L1Message,
     blockIdentifier?: BlockIdentifier
-  ): Promise<RPCSPEC0101.FEE_ESTIMATE | RPCSPEC09.MESSAGE_FEE_ESTIMATE>;
+  ): Promise<RPCSPEC0103.FEE_ESTIMATE | RPCSPEC09.MESSAGE_FEE_ESTIMATE>;
 
   /**
    * Get node synchronization status
@@ -600,8 +600,8 @@ export abstract class ProviderInterface {
    * @returns Events and pagination info
    */
   public abstract getEvents(
-    eventFilter: RPCSPEC0101.EventFilter | RPCSPEC09.EventFilter
-  ): Promise<RPCSPEC0101.EVENTS_CHUNK | RPCSPEC09.EVENTS_CHUNK>;
+    eventFilter: RPCSPEC0103.EventFilter | RPCSPEC09.EventFilter
+  ): Promise<RPCSPEC0103.EVENTS_CHUNK | RPCSPEC09.EVENTS_CHUNK>;
 
   /**
    * Verify in Starknet a signature of a TypedData object or of a given hash.
@@ -658,7 +658,7 @@ export abstract class ProviderInterface {
    */
   public abstract getL1MessagesStatus(
     transactionHash: BigNumberish
-  ): Promise<RPC.RPCSPEC0101.L1L2MessagesStatus | RPC.RPCSPEC09.L1L2MessagesStatus>;
+  ): Promise<RPC.RPCSPEC0103.L1L2MessagesStatus | RPC.RPCSPEC09.L1L2MessagesStatus>;
 
   /**
    * Get Merkle paths in state tries

--- a/src/provider/modules/getGasPrices.ts
+++ b/src/provider/modules/getGasPrices.ts
@@ -1,8 +1,8 @@
-import type { RPC09, RPC0101 } from '../../channel';
+import type { RPC09, RPC0102 } from '../../channel';
 import type { BlockIdentifier, BlockWithTxHashes, GasPrices } from '../../types';
 
 export async function getGasPrices(
-  channel: RPC09.RpcChannel | RPC0101.RpcChannel,
+  channel: RPC09.RpcChannel | RPC0102.RpcChannel,
   blockIdentifier: BlockIdentifier = channel.blockIdentifier
 ): Promise<GasPrices> {
   const bl = (await channel.getBlockWithTxHashes(blockIdentifier)) as BlockWithTxHashes;

--- a/src/provider/modules/responseParser/rpc.ts
+++ b/src/provider/modules/responseParser/rpc.ts
@@ -13,7 +13,7 @@ import type {
   SimulateTransactionOverheadResponse,
   EstimateFeeResponseBulkOverhead,
 } from '../../types/index.type';
-import { RPCSPEC0101 } from '../../../types/api';
+import { RPCSPEC0103 } from '../../../types/api';
 import { isString } from '../../../utils/typed';
 import { toOverheadOverallFee, toOverheadResourceBounds } from '../../../utils/stark';
 import { ResponseParser } from './interface';
@@ -87,8 +87,8 @@ export class RPCResponseParser implements Omit<
   }
 
   public parseStorageResponse(
-    res: RPCSPEC0101.FELT | RPCSPEC0101.STORAGE_RESULT
-  ): RPCSPEC0101.STORAGE_RESULT {
+    res: RPCSPEC0103.FELT | RPCSPEC0103.STORAGE_RESULT
+  ): RPCSPEC0103.STORAGE_RESULT {
     // Normalize response: wrap FELT (string) in STORAGE_RESULT if needed
     if (typeof res === 'string') {
       return { value: res, last_update_block: 0 };

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -1,4 +1,4 @@
-import { RPC09, RPC0101 } from '../channel';
+import { RPC09, RPC0102, RPC0103 } from '../channel';
 import { config } from '../global/config';
 import { SupportedRpcVersion, type SupportedRpcVersion0_10 } from '../global/constants';
 import { logger } from '../global/logger';
@@ -34,7 +34,7 @@ import {
   type TypedData,
   waitForTransactionOptions,
 } from '../types';
-import { ETransactionType, RPCSPEC0101, RPCSPEC09 } from '../types/api';
+import { ETransactionType, RPCSPEC0103, RPCSPEC09 } from '../types/api';
 import assert from '../utils/assert';
 import { getAbiContractVersion } from '../utils/calldata/cairo';
 import { extractContractHashes, isSierra } from '../utils/contract';
@@ -63,7 +63,7 @@ import type { StarknetPlugin } from '../plugins/types';
 export class RpcProvider implements ProviderInterface {
   public responseParser: RPCResponseParser;
 
-  public channel: RPC09.RpcChannel | RPC0101.RpcChannel;
+  public channel: RPC09.RpcChannel | RPC0102.RpcChannel | RPC0103.RpcChannel;
 
   /** @internal Plugin management infrastructure */
   public readonly pluginManager: PluginManager;
@@ -91,14 +91,14 @@ export class RpcProvider implements ProviderInterface {
         if (isVersion('0.9', options.specVersion)) {
           this.channel = new RPC09.RpcChannel({ ...options, waitMode: false });
         } else if (isVersion('0.10', options.specVersion)) {
-          this.channel = new RPC0101.RpcChannel({ ...options, waitMode: false });
+          this.channel = new RPC0103.RpcChannel({ ...options, waitMode: false });
         } else throw new Error(`unsupported channel for spec version: ${options.specVersion}`);
       } else if (isVersion('0.9', config.get('rpcVersion'))) {
         // default channel when unspecified
         this.channel = new RPC09.RpcChannel({ ...options, waitMode: false });
       } else if (isVersion('0.10', config.get('rpcVersion'))) {
         // default channel when unspecified
-        this.channel = new RPC0101.RpcChannel({ ...options, waitMode: false });
+        this.channel = new RPC0103.RpcChannel({ ...options, waitMode: false });
       } else throw new Error('unable to define spec version for channel');
 
       this.responseParser = new RPCResponseParser(options?.resourceBoundsOverhead);
@@ -137,7 +137,7 @@ export class RpcProvider implements ProviderInterface {
     if (isVersion('0.10', spec)) {
       return new this({
         ...optionsOrProvider,
-        specVersion: SupportedRpcVersion.v0_10_2,
+        specVersion: SupportedRpcVersion.v0_10_3,
       }) as T;
     }
 
@@ -232,7 +232,7 @@ export class RpcProvider implements ProviderInterface {
     blockIdentifier?: BlockIdentifier,
     options?: { includeProofFacts?: boolean }
   ) {
-    if (this.channel instanceof RPC0101.RpcChannel) {
+    if (this.channel instanceof RPC0102.RpcChannel) {
       return this.channel.getBlockWithTxs(blockIdentifier, options);
     }
     return this.channel.getBlockWithTxs(blockIdentifier);
@@ -310,7 +310,7 @@ export class RpcProvider implements ProviderInterface {
     blockIdentifier?: BlockIdentifier,
     options?: { includeProofFacts?: boolean }
   ) {
-    if (this.channel instanceof RPC0101.RpcChannel) {
+    if (this.channel instanceof RPC0102.RpcChannel) {
       return this.channel.getBlockWithReceipts(blockIdentifier, options);
     }
     return this.channel.getBlockWithReceipts(blockIdentifier);
@@ -338,7 +338,7 @@ export class RpcProvider implements ProviderInterface {
     blockIdentifier?: BlockIdentifier,
     options?: { returnInitialReads?: boolean }
   ) {
-    if (this.channel instanceof RPC0101.RpcChannel) {
+    if (this.channel instanceof RPC0102.RpcChannel) {
       return this.channel.getBlockTransactionsTraces(blockIdentifier, options);
     }
     return this.channel.getBlockTransactionsTraces(blockIdentifier);
@@ -356,7 +356,7 @@ export class RpcProvider implements ProviderInterface {
     txHash: BigNumberish,
     options?: { includeProofFacts?: boolean }
   ) {
-    if (this.channel instanceof RPC0101.RpcChannel) {
+    if (this.channel instanceof RPC0102.RpcChannel) {
       return this.channel.getTransactionByHash(txHash, options);
     }
     return this.channel.getTransactionByHash(txHash);
@@ -367,7 +367,7 @@ export class RpcProvider implements ProviderInterface {
     index: number,
     options?: { includeProofFacts?: boolean }
   ) {
-    if (this.channel instanceof RPC0101.RpcChannel) {
+    if (this.channel instanceof RPC0102.RpcChannel) {
       return this.channel.getTransactionByBlockIdAndIndex(blockIdentifier, index, options);
     }
     return this.channel.getTransactionByBlockIdAndIndex(blockIdentifier, index);
@@ -383,14 +383,14 @@ export class RpcProvider implements ProviderInterface {
   public async getTransactionTrace<V extends SupportedRpcVersion = SupportedRpcVersion>(
     txHash: BigNumberish
   ): Promise<
-    V extends SupportedRpcVersion0_10 ? RPCSPEC0101.TRANSACTION_TRACE : RPCSPEC09.TRANSACTION_TRACE
+    V extends SupportedRpcVersion0_10 ? RPCSPEC0103.TRANSACTION_TRACE : RPCSPEC09.TRANSACTION_TRACE
   >;
   public async getTransactionTrace(
     txHash: BigNumberish
-  ): Promise<RPCSPEC0101.TRANSACTION_TRACE | RPCSPEC09.TRANSACTION_TRACE>;
+  ): Promise<RPCSPEC0103.TRANSACTION_TRACE | RPCSPEC09.TRANSACTION_TRACE>;
   public async getTransactionTrace(
     txHash: BigNumberish
-  ): Promise<RPCSPEC0101.TRANSACTION_TRACE | RPCSPEC09.TRANSACTION_TRACE> {
+  ): Promise<RPCSPEC0103.TRANSACTION_TRACE | RPCSPEC09.TRANSACTION_TRACE> {
     return this.channel.getTransactionTrace(txHash);
   }
 
@@ -424,7 +424,7 @@ export class RpcProvider implements ProviderInterface {
     contractAddress: BigNumberish,
     key: BigNumberish,
     blockIdentifier?: BlockIdentifier,
-    responseFlags?: RPCSPEC0101.STORAGE_RESPONSE_FLAG[]
+    responseFlags?: RPCSPEC0103.STORAGE_RESPONSE_FLAG[]
   ) {
     const result = await this.channel.getStorageAt(
       contractAddress,
@@ -573,16 +573,16 @@ export class RpcProvider implements ProviderInterface {
     message: RPCSPEC09.L1Message,
     blockIdentifier?: BlockIdentifier
   ): Promise<
-    V extends SupportedRpcVersion0_10 ? RPCSPEC0101.FEE_ESTIMATE : RPCSPEC09.MESSAGE_FEE_ESTIMATE
+    V extends SupportedRpcVersion0_10 ? RPCSPEC0103.FEE_ESTIMATE : RPCSPEC09.MESSAGE_FEE_ESTIMATE
   >;
   public async estimateMessageFee(
     message: RPCSPEC09.L1Message,
     blockIdentifier?: BlockIdentifier
-  ): Promise<RPCSPEC0101.FEE_ESTIMATE | RPCSPEC09.MESSAGE_FEE_ESTIMATE>;
+  ): Promise<RPCSPEC0103.FEE_ESTIMATE | RPCSPEC09.MESSAGE_FEE_ESTIMATE>;
   public async estimateMessageFee(
     message: RPCSPEC09.L1Message, // same as spec08.L1Message
     blockIdentifier?: BlockIdentifier
-  ): Promise<RPCSPEC0101.FEE_ESTIMATE | RPCSPEC09.MESSAGE_FEE_ESTIMATE> {
+  ): Promise<RPCSPEC0103.FEE_ESTIMATE | RPCSPEC09.MESSAGE_FEE_ESTIMATE> {
     return this.channel.estimateMessageFee(message, blockIdentifier);
   }
 
@@ -591,16 +591,16 @@ export class RpcProvider implements ProviderInterface {
   }
 
   public async getEvents<V extends SupportedRpcVersion = SupportedRpcVersion>(
-    eventFilter: V extends SupportedRpcVersion0_10 ? RPCSPEC0101.EventFilter : RPCSPEC09.EventFilter
-  ): Promise<V extends SupportedRpcVersion0_10 ? RPCSPEC0101.EVENTS_CHUNK : RPCSPEC09.EVENTS_CHUNK>;
+    eventFilter: V extends SupportedRpcVersion0_10 ? RPCSPEC0103.EventFilter : RPCSPEC09.EventFilter
+  ): Promise<V extends SupportedRpcVersion0_10 ? RPCSPEC0103.EVENTS_CHUNK : RPCSPEC09.EVENTS_CHUNK>;
   public async getEvents(
-    eventFilter: RPCSPEC0101.EventFilter | RPCSPEC09.EventFilter
-  ): Promise<RPCSPEC0101.EVENTS_CHUNK | RPCSPEC09.EVENTS_CHUNK>;
+    eventFilter: RPCSPEC0103.EventFilter | RPCSPEC09.EventFilter
+  ): Promise<RPCSPEC0103.EVENTS_CHUNK | RPCSPEC09.EVENTS_CHUNK>;
   public async getEvents(
-    eventFilter: RPCSPEC0101.EventFilter | RPCSPEC09.EventFilter
-  ): Promise<RPCSPEC0101.EVENTS_CHUNK | RPCSPEC09.EVENTS_CHUNK> {
-    if (this.channel instanceof RPC0101.RpcChannel) {
-      return this.channel.getEvents(eventFilter as RPCSPEC0101.EventFilter);
+    eventFilter: RPCSPEC0103.EventFilter | RPCSPEC09.EventFilter
+  ): Promise<RPCSPEC0103.EVENTS_CHUNK | RPCSPEC09.EVENTS_CHUNK> {
+    if (this.channel instanceof RPC0102.RpcChannel) {
+      return this.channel.getEvents(eventFilter as RPCSPEC0103.EventFilter);
     }
     if (this.channel instanceof RPC09.RpcChannel) {
       return this.channel.getEvents(eventFilter as RPCSPEC09.EventFilter);
@@ -678,15 +678,15 @@ export class RpcProvider implements ProviderInterface {
     transactionHash: BigNumberish
   ): Promise<
     V extends SupportedRpcVersion0_10
-      ? RPC.RPCSPEC0101.L1L2MessagesStatus
+      ? RPC.RPCSPEC0103.L1L2MessagesStatus
       : RPC.RPCSPEC09.L1L2MessagesStatus
   >;
   public async getL1MessagesStatus(
     transactionHash: BigNumberish
-  ): Promise<RPC.RPCSPEC0101.L1L2MessagesStatus | RPC.RPCSPEC09.L1L2MessagesStatus>;
+  ): Promise<RPC.RPCSPEC0103.L1L2MessagesStatus | RPC.RPCSPEC09.L1L2MessagesStatus>;
   public async getL1MessagesStatus(
     transactionHash: BigNumberish
-  ): Promise<RPC.RPCSPEC0101.L1L2MessagesStatus | RPC.RPCSPEC09.L1L2MessagesStatus> {
+  ): Promise<RPC.RPCSPEC0103.L1L2MessagesStatus | RPC.RPCSPEC09.L1L2MessagesStatus> {
     return this.channel.getMessagesStatus(transactionHash);
   }
 

--- a/src/provider/types/response.type.ts
+++ b/src/provider/types/response.type.ts
@@ -9,7 +9,7 @@ import {
   IsSucceeded,
   IsType,
   PRE_CONFIRMED_BLOCK_WITH_TX_HASHES,
-  RPCSPEC0101,
+  RPCSPEC0103,
   TransactionReceipt,
 } from '../../types/api';
 
@@ -62,7 +62,7 @@ export type DeclareContractResponse = DeclaredTransaction;
 
 export type CallContractResponse = string[];
 
-export type StorageResponse = RPCSPEC0101.STORAGE_RESULT;
+export type StorageResponse = RPCSPEC0103.STORAGE_RESULT;
 
 export type Nonce = string;
 

--- a/src/provider/types/spec.type.ts
+++ b/src/provider/types/spec.type.ts
@@ -1,7 +1,7 @@
 // this file aims to unify the RPC specification types used by the common Provider class
 
 import { SimpleOneOf } from '../../types/helpers';
-import { RPCSPEC09, RPCSPEC0101 } from '../../types/api';
+import { RPCSPEC09, RPCSPEC0103 } from '../../types/api';
 
 // taken from type-fest
 export type Simplify<T> = { [K in keyof T]: T[K] } & {};
@@ -62,22 +62,22 @@ export type ETransactionVersion3 = RPCSPEC09.ETransactionVersion3;
 export const { ETransactionVersion3 } = RPCSPEC09;
 
 // MERGES
-export type BLOCK_HASH = Merge<RPCSPEC0101.BLOCK_HASH, RPCSPEC09.BLOCK_HASH>;
-export type BLOCK_NUMBER = Merge<RPCSPEC0101.BLOCK_NUMBER, RPCSPEC09.BLOCK_NUMBER>;
-export type FELT = Merge<RPCSPEC0101.FELT, RPCSPEC09.FELT>;
-export type TXN_HASH = Merge<RPCSPEC0101.TXN_HASH, RPCSPEC09.TXN_HASH>;
+export type BLOCK_HASH = Merge<RPCSPEC0103.BLOCK_HASH, RPCSPEC09.BLOCK_HASH>;
+export type BLOCK_NUMBER = Merge<RPCSPEC0103.BLOCK_NUMBER, RPCSPEC09.BLOCK_NUMBER>;
+export type FELT = Merge<RPCSPEC0103.FELT, RPCSPEC09.FELT>;
+export type TXN_HASH = Merge<RPCSPEC0103.TXN_HASH, RPCSPEC09.TXN_HASH>;
 
-export type PRICE_UNIT = Merge<RPCSPEC0101.PRICE_UNIT, RPCSPEC09.PRICE_UNIT>;
-export type RESOURCE_PRICE = Merge<RPCSPEC0101.RESOURCE_PRICE, RPCSPEC09.RESOURCE_PRICE>;
-export type SIMULATION_FLAG = Merge<RPCSPEC0101.SIMULATION_FLAG, RPCSPEC09.SIMULATION_FLAG>;
+export type PRICE_UNIT = Merge<RPCSPEC0103.PRICE_UNIT, RPCSPEC09.PRICE_UNIT>;
+export type RESOURCE_PRICE = Merge<RPCSPEC0103.RESOURCE_PRICE, RPCSPEC09.RESOURCE_PRICE>;
+export type SIMULATION_FLAG = Merge<RPCSPEC0103.SIMULATION_FLAG, RPCSPEC09.SIMULATION_FLAG>;
 
-export type STATE_UPDATE = Merge<RPCSPEC0101.STATE_UPDATE, RPCSPEC09.STATE_UPDATE>;
+export type STATE_UPDATE = Merge<RPCSPEC0103.STATE_UPDATE, RPCSPEC09.STATE_UPDATE>;
 /* export type PENDING_STATE_UPDATE = Merge<
-  RPCSPEC0101.PENDING_STATE_UPDATE,
+  RPCSPEC0103.PENDING_STATE_UPDATE,
   RPCSPEC09.PRE_CONFIRMED_STATE_UPDATE
 >; */
 export type PRE_CONFIRMED_STATE_UPDATE = Merge<
-  RPCSPEC0101.PRE_CONFIRMED_STATE_UPDATE,
+  RPCSPEC0103.PRE_CONFIRMED_STATE_UPDATE,
   RPCSPEC09.PRE_CONFIRMED_STATE_UPDATE
 >;
 // TODO: Can we remove all of this ?
@@ -102,47 +102,47 @@ export type PENDING_L1_HANDLER_TXN_RECEIPT = RPCSPEC08.IsPending<
 >; */
 //
 
-export type BlockWithTxHashes = Merge<RPCSPEC0101.BlockWithTxHashes, RPCSPEC09.BlockWithTxHashes>;
-export type ContractClassPayload = Merge<RPCSPEC0101.ContractClass, RPCSPEC09.ContractClass>;
+export type BlockWithTxHashes = Merge<RPCSPEC0103.BlockWithTxHashes, RPCSPEC09.BlockWithTxHashes>;
+export type ContractClassPayload = Merge<RPCSPEC0103.ContractClass, RPCSPEC09.ContractClass>;
 export type DeclaredTransaction = Merge<
-  RPCSPEC0101.DeclaredTransaction,
+  RPCSPEC0103.DeclaredTransaction,
   RPCSPEC09.DeclaredTransaction
 >;
 export type InvokedTransaction = Merge<
-  RPCSPEC0101.InvokedTransaction,
+  RPCSPEC0103.InvokedTransaction,
   RPCSPEC09.InvokedTransaction
 >;
 export type DeployedAccountTransaction = Merge<
-  RPCSPEC0101.DeployedAccountTransaction,
+  RPCSPEC0103.DeployedAccountTransaction,
   RPCSPEC09.DeployedAccountTransaction
 >;
 
-export type L1_HANDLER_TXN = RPCSPEC0101.L1_HANDLER_TXN;
-export type EDataAvailabilityMode = RPCSPEC0101.EDataAvailabilityMode;
-export const { EDataAvailabilityMode } = RPCSPEC0101;
-export type EDAMode = RPCSPEC0101.EDAMode;
-export const { EDAMode } = RPCSPEC0101;
-export type EmittedEvent = Merge<RPCSPEC0101.EmittedEvent, RPCSPEC09.EmittedEvent>;
-export type Event = Merge<RPCSPEC0101.Event, RPCSPEC09.Event>;
+export type L1_HANDLER_TXN = RPCSPEC0103.L1_HANDLER_TXN;
+export type EDataAvailabilityMode = RPCSPEC0103.EDataAvailabilityMode;
+export const { EDataAvailabilityMode } = RPCSPEC0103;
+export type EDAMode = RPCSPEC0103.EDAMode;
+export const { EDAMode } = RPCSPEC0103;
+export type EmittedEvent = Merge<RPCSPEC0103.EmittedEvent, RPCSPEC09.EmittedEvent>;
+export type Event = Merge<RPCSPEC0103.Event, RPCSPEC09.Event>;
 
 /* export type PendingReceipt = Merge<
-  RPCSPEC0101.TransactionReceiptPendingBlock,
+  RPCSPEC0103.TransactionReceiptPendingBlock,
   RPCSPEC09.TransactionReceiptPreConfirmedBlock
 >; */
 export type Receipt = Merge<
-  RPCSPEC0101.TransactionReceiptProductionBlock,
+  RPCSPEC0103.TransactionReceiptProductionBlock,
   RPCSPEC09.TransactionReceiptProductionBlock
 >;
 
 /**
  * original response from estimate fee without parsing
  */
-export type FeeEstimate = Merge<RPCSPEC0101.FEE_ESTIMATE, RPCSPEC09.FEE_ESTIMATE>;
+export type FeeEstimate = Merge<RPCSPEC0103.FEE_ESTIMATE, RPCSPEC09.FEE_ESTIMATE>;
 export type ApiEstimateFeeResponse = FeeEstimate[]; // 0.8 and 0.9
 
 export function isRPC08Plus_ResourceBounds(
   entry: ResourceBounds
-): entry is RPCSPEC0101.ResourceBounds {
+): entry is RPCSPEC0103.ResourceBounds {
   return 'l1_data_gas' in entry;
 }
 
@@ -150,7 +150,7 @@ export function isRPC08Plus_ResourceBoundsBN(entry: ResourceBoundsBN): entry is 
   return 'l1_data_gas' in entry;
 }
 
-export type ResourceBounds = Merge<RPCSPEC0101.ResourceBounds, RPCSPEC09.ResourceBounds>; // same sa rpc0.8
+export type ResourceBounds = Merge<RPCSPEC0103.ResourceBounds, RPCSPEC09.ResourceBounds>; // same sa rpc0.8
 
 export type EventFilter = RPCSPEC09.EventFilter;
 
@@ -179,60 +179,60 @@ export type ResourceBoundsBN = {
 
 export type SimulateTransaction = SimpleOneOf<
   RPCSPEC09.SimulateTransaction,
-  RPCSPEC0101.SimulateTransaction
+  RPCSPEC0103.SimulateTransaction
 >;
 export type SimulateTransactionResponse =
   | RPCSPEC09.SimulateTransactionResponse
-  | RPCSPEC0101.SimulateTransactionResponse;
+  | RPCSPEC0103.SimulateTransactionResponse;
 
-export type INITIAL_READS = RPCSPEC0101.INITIAL_READS;
+export type INITIAL_READS = RPCSPEC0103.INITIAL_READS;
 
 /** Flags to request additional fields in transaction responses (RPC 0.10.1+) */
-export type ETxnResponseFlag = RPCSPEC0101.ETxnResponseFlag;
-export const { ETxnResponseFlag } = RPCSPEC0101;
+export type ETxnResponseFlag = RPCSPEC0103.ETxnResponseFlag;
+export const { ETxnResponseFlag } = RPCSPEC0103;
 
 /** Flags to request additional fields in trace responses (RPC 0.10.1+) */
-export type ETraceFlag = RPCSPEC0101.ETraceFlag;
-export const { ETraceFlag } = RPCSPEC0101;
+export type ETraceFlag = RPCSPEC0103.ETraceFlag;
+export const { ETraceFlag } = RPCSPEC0103;
 
 /** Tags for WebSocket transaction subscriptions (RPC 0.10.1+) */
-export type ESubscriptionTag = RPCSPEC0101.ESubscriptionTag;
-export const { ESubscriptionTag } = RPCSPEC0101;
+export type ESubscriptionTag = RPCSPEC0103.ESubscriptionTag;
+export const { ESubscriptionTag } = RPCSPEC0103;
 
 /** A single transaction trace within a block */
-export type BlockTransactionTrace = RPCSPEC0101.BlockTransactionTrace;
+export type BlockTransactionTrace = RPCSPEC0103.BlockTransactionTrace;
 /** Block transaction traces with optional initial storage reads (RPC 0.10.1+) */
 export type BlockTransactionsTracesWithInitialReads =
-  RPCSPEC0101.BlockTransactionsTracesWithInitialReads;
+  RPCSPEC0103.BlockTransactionsTracesWithInitialReads;
 
 export type TransactionTrace = SimpleOneOf<
   RPCSPEC09.TRANSACTION_TRACE,
-  RPCSPEC0101.TRANSACTION_TRACE
+  RPCSPEC0103.TRANSACTION_TRACE
 >;
 
 export type TransactionWithHash = Merge<
-  RPCSPEC0101.TransactionWithHash,
+  RPCSPEC0103.TransactionWithHash,
   RPCSPEC09.TransactionWithHash
 >;
 
 export type TransactionReceipt = Merge<
-  RPCSPEC0101.TransactionReceipt,
+  RPCSPEC0103.TransactionReceipt,
   RPCSPEC09.TransactionReceipt
 >;
-export type Methods = RPCSPEC0101.Methods;
-export type TXN_STATUS = Merge<RPCSPEC0101.TXN_STATUS, RPCSPEC09.TXN_STATUS>;
+export type Methods = RPCSPEC0103.Methods;
+export type TXN_STATUS = Merge<RPCSPEC0103.TXN_STATUS, RPCSPEC09.TXN_STATUS>;
 export type TXN_EXECUTION_STATUS = Merge<
-  RPCSPEC0101.TXN_EXECUTION_STATUS,
+  RPCSPEC0103.TXN_EXECUTION_STATUS,
   RPCSPEC09.TXN_EXECUTION_STATUS
 >;
-export type TransactionStatus = Merge<RPCSPEC0101.TransactionStatus, RPCSPEC09.TransactionStatus>;
-export type ETransactionStatus = RPCSPEC0101.ETransactionStatus;
-export const { ETransactionStatus } = RPCSPEC0101;
-export type ETransactionExecutionStatus = RPCSPEC0101.ETransactionExecutionStatus;
-export const { ETransactionExecutionStatus } = RPCSPEC0101;
+export type TransactionStatus = Merge<RPCSPEC0103.TransactionStatus, RPCSPEC09.TransactionStatus>;
+export type ETransactionStatus = RPCSPEC0103.ETransactionStatus;
+export const { ETransactionStatus } = RPCSPEC0103;
+export type ETransactionExecutionStatus = RPCSPEC0103.ETransactionExecutionStatus;
+export const { ETransactionExecutionStatus } = RPCSPEC0103;
 // export type TRANSACTION_TRACE = Merge<RPCSPEC08.TRANSACTION_TRACE, RPCSPEC09.TRANSACTION_TRACE>;
-export type FEE_ESTIMATE = Merge<RPCSPEC0101.FEE_ESTIMATE, RPCSPEC09.FEE_ESTIMATE>;
-export type EVENTS_CHUNK = Merge<RPCSPEC0101.EVENTS_CHUNK, RPCSPEC09.EVENTS_CHUNK>;
+export type FEE_ESTIMATE = Merge<RPCSPEC0103.FEE_ESTIMATE, RPCSPEC09.FEE_ESTIMATE>;
+export type EVENTS_CHUNK = Merge<RPCSPEC0103.EVENTS_CHUNK, RPCSPEC09.EVENTS_CHUNK>;
 
 export type TransactionType = RPCSPEC09.ETransactionType;
 export const { ETransactionType: TransactionType } = RPCSPEC09;

--- a/src/types/api/index.ts
+++ b/src/types/api/index.ts
@@ -1,9 +1,9 @@
 export * as JRPC from './jsonrpc';
 
 export * as RPCSPEC09 from '@starknet-io/starknet-types-09';
-export * as RPCSPEC0101 from '@starknet-io/starknet-types-0101';
+export * as RPCSPEC0103 from '@starknet-io/starknet-types-0103';
 
-export { PAYMASTER_API } from '@starknet-io/starknet-types-0101';
+export { PAYMASTER_API } from '@starknet-io/starknet-types-0103';
 
 // Default export
 // alias for "export * from '@starknet-io/starknet-types-09';" which is done within ./rpc.ts

--- a/src/types/api/rpc.ts
+++ b/src/types/api/rpc.ts
@@ -1,2 +1,2 @@
 // see explanation in ./index.ts
-export * from '@starknet-io/starknet-types-0101';
+export * from '@starknet-io/starknet-types-0103';

--- a/www/docs/guides/configuration.md
+++ b/www/docs/guides/configuration.md
@@ -17,7 +17,7 @@ Custom keys can also be used to store and use arbitrary values during runtime.
 import { config } from 'starknet';
 
 // Set existing or custom global property
-config.set('rpcVersion', '0.9.1');
+config.set('rpcVersion', '0.9.0');
 
 // Set WebSocket implementation for Node.js (if using older than Node.js 22)
 import WebSocket from 'ws';
@@ -65,8 +65,8 @@ Here are all the available configuration properties:
 
 ```ts
 {
-  // RPC version to use when communicating with nodes ('0.8.1' or '0.9.1')
-  rpcVersion: '0.9.1',
+  // RPC version to use when communicating with nodes ('0.9.0', '0.10.0', '0.10.2', '0.10.3')
+  rpcVersion: '0.10.0',
 
   // Transaction version to use (only V3 is supported in v8)
   transactionVersion: ETransactionVersion.V3,

--- a/www/docs/guides/migrate.md
+++ b/www/docs/guides/migrate.md
@@ -634,6 +634,50 @@ When upgrading from v9 to v10:
   - [ ] Verify all provider method calls work with `account.provider.xyz()`
   - [ ] Test plugin functionality (StarknetId, BrotherId)
 
+## RPC 0.10.3 Support (v10.x)
+
+Starknet.js v10.x adds support for RPC spec 0.10.3 as the new default version. Two public exports were renamed to reflect this:
+
+### `RPCSPEC0101` → `RPCSPEC0103`
+
+The namespace re-exporting the current 0.10.x RPC spec types was renamed.
+
+**❌ Before:**
+
+```typescript
+import { RPCSPEC0101 } from 'starknet';
+
+type MyBlock = RPCSPEC0101.BLOCK_WITH_TXS;
+```
+
+**✅ After:**
+
+```typescript
+import { RPCSPEC0103 } from 'starknet';
+
+type MyBlock = RPCSPEC0103.BLOCK_WITH_TXS;
+```
+
+### `RPC0101` → `RPC0102`
+
+The channel namespace for the RPC 0.10.2 implementation was renamed.
+
+**❌ Before:**
+
+```typescript
+import { RPC0101 } from 'starknet';
+```
+
+**✅ After:**
+
+```typescript
+import { RPC0102 } from 'starknet';
+```
+
+:::note
+These changes only affect advanced usage (raw RPC spec types and direct channel imports). Standard usage via `RpcProvider`, `Account`, and high-level methods is unaffected.
+:::
+
 ## Need Help?
 
 - Check the [Plugin System Guide](./plugins.md) for details on how plugins work

--- a/www/docs/guides/provider_instance.md
+++ b/www/docs/guides/provider_instance.md
@@ -30,17 +30,18 @@ From RPC v0.5.0, you can make a request to retrieve the RPC version that a node 
 ```typescript
 const resp = await myProvider.getSpecVersion();
 console.log('RPC version =', resp);
-// result: RPC version = 0.10.0
+// result: RPC version = 0.10.3
 ```
 
 The Starknet.js version must align with the RPC version supported by the chosen node as shown below:
 
-| RPC spec version of your node | Starknet.js version to use    |
-| :---------------------------: | ----------------------------- |
-|            v0.7.x             | Starknet.js v6.24.1 or v7.x.x |
-|            v0.8.x             | Starknet.js v7.x.x or v8.x.x  |
-|            v0.9.x             | Starknet.js v8.x.x or v9.x.x  |
-|            v0.10.x            | Starknet.js v9.x.x            |
+| RPC spec version of your node | Starknet.js version to use            |
+| :---------------------------: | ------------------------------------- |
+|            v0.7.x             | Starknet.js v6.24.1 or v7.x.x         |
+|            v0.8.x             | Starknet.js v7.x.x or v8.x.x          |
+|            v0.9.x             | Starknet.js v8.x.x, v9.x.x or v10.x.x |
+|            v0.10.0            | Starknet.js v9.x.x or v10.x.x         |
+|       v0.10.2 and above       | Starknet.js v10.x.x                   |
 
 :::note
 
@@ -99,7 +100,7 @@ import { RpcProvider } from 'starknet';
 
 ### Default RPC node
 
-If you don't want to use a specific node or to handle an API key, you can use one of the defaults (using RPC spec v0.10.0):
+If you don't want to use a specific node or to handle an API key, you can use one of the defaults (using RPC spec v0.10.3):
 
 ```typescript
 const myProvider = new RpcProvider({ nodeUrl: constants.NetworkName.SN_SEPOLIA });


### PR DESCRIPTION
## Motivation and Resolution

Add support for Starknet RPC spec **0.10.3** (`starknet-types-0103`), which introduces updated type definitions via the `@starknet-io/types-js@0.10.3-beta.1` package.

The previous default channel (`RpcChannel v0.10.2`) and its associated `RPCSPEC0101` types are preserved as `RPC0102` for backward compatibility. `RpcChannel v0.10.3` becomes the new default, backed by `RPCSPEC0103`.

### RPC version (if applicable)

RPC spec **0.10.3** (`@starknet-io/types-js@0.10.3-beta.1`)

## Usage related changes

- `RPCSPEC0103` replaces `RPCSPEC0101` as the default RPC type namespace (re-exported as `RPC` from the public API).
- New `RPC0103` channel export available for explicit versioning (`import { RPC0103 } from 'starknet/channel'`).
- Previous `RPC0101` channel export renamed to `RPC0102` to reflect the actual spec version it targets.
- `SupportedRpcVersion.v0_10_3` / `'0.10.3'` added to the supported version constants.
- Migration guide updated with the breaking changes introduced by RPC 0.10.3.
- Provider instance guide updated to reflect the new default channel.

## Development related changes

- Added `@starknet-io/starknet-types-0103` dependency resolved via `npm:@starknet-io/types-js@0.10.3-beta.1`.
- `src/channel/rpc_0_10_3.ts` — minimal `RpcChannel` subclass that sets `channelSpecVersion` to `v0_10_3` and overrides `id`.
- `src/channel/rpc_0_10_2.ts` — now imports directly from `@starknet-io/starknet-types-0101` rather than through the re-export barrel, so the barrel can cleanly point `RPCSPEC0103` as the default.
- All provider/channel type signatures updated from `RPCSPEC0101` → `RPCSPEC0103`.

## Checklist:

- [x] Performed a self-review of the code
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
