### PR TITLE
add Byte array hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ node_modules
 npm-debug.log
 package
 yarn.lock
-CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ node_modules
 npm-debug.log
 package
 yarn.lock
+CLAUDE.md

--- a/__tests__/utils/cairoDataTypes/CairoByteArray.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoByteArray.test.ts
@@ -718,6 +718,44 @@ describe('CairoByteArray Unit Tests', () => {
     });
   });
 
+  describe('hash method', () => {
+    test('should hash a short string (pending word only)', () => {
+      const byteArray = new CairoByteArray('Hello');
+      expect(byteArray.hash()).toBe(
+        '0x15d19ad651ffaf8e90a13938db2081fa3ff01de0712e00cbe69891bace66c51'
+      );
+    });
+
+    test('should hash an empty ByteArray', () => {
+      const byteArray = new CairoByteArray('');
+      expect(byteArray.hash()).toBe(
+        '0xba8cc6e828441028f48901de0bdb28a41b043e873062de3e6a44c7f6a93543'
+      );
+    });
+
+    test('should hash a ByteArray of exactly 31 bytes (one full data chunk)', () => {
+      const byteArray = new CairoByteArray('This is exactly 31 bytes long!!');
+      expect(byteArray.hash()).toBe(
+        '0x3cffa4720c41eb3693a668a0cd480953c2fb9deab9081377486ed8056161995'
+      );
+    });
+
+    test('should hash a ByteArray spanning multiple data chunks', () => {
+      const byteArray = new CairoByteArray(
+        'This is a very long string that exceeds 31 bytes limit for testing'
+      );
+      expect(byteArray.hash()).toBe(
+        '0x6867c4e6970706dc2e7a3afed7508e14b6244222a43c0981308304fa6f59b1d'
+      );
+    });
+
+    test('should throw error if not properly initialized', () => {
+      const byteArray = new CairoByteArray('test');
+      (byteArray as any).data = undefined;
+      expect(() => byteArray.hash()).toThrow('CairoByteArray is not properly initialized');
+    });
+  });
+
   describe('toElements method', () => {
     test('should convert empty string to empty array', () => {
       const byteArray = new CairoByteArray('');

--- a/src/utils/cairoDataTypes/byteArray.ts
+++ b/src/utils/cairoDataTypes/byteArray.ts
@@ -8,6 +8,7 @@ import {
   concatenateArrayBuffer,
   stringToUint8Array,
 } from '../encode';
+import { computeHashOnElements } from '../hash/pedersenCore';
 import { getNext } from '../num';
 import { isBigInt, isBuffer, isInteger, isNumber, isString } from '../typed';
 import { addCompiledFlag } from '../helpers';
@@ -169,6 +170,32 @@ export class CairoByteArray {
   toBuffer() {
     const allBytes = concatenateArrayBuffer(this.toElements());
     return Buffer.from(allBytes);
+  }
+
+  /**
+   * Compute the Pedersen hash of this ByteArray, following OpenZeppelin's `hash_byte_array` algorithm.
+   *
+   * Serializes the ByteArray to its felt252 components (data array length, each data chunk,
+   * pending_word, pending_word_len), then chains Pedersen hash over all elements starting
+   * from 0, and finalizes with the total element count.
+   *
+   * @returns {string} hex-string felt252 Pedersen hash of the ByteArray
+   * @example
+   * ```typescript
+   * const ba = new CairoByteArray('Hello');
+   * const result = ba.hash();
+   * // result = 0x15d19ad651ffaf8e90a13938db2081fa3ff01de0712e00cbe69891bace66c51
+   * ```
+   */
+  hash(): string {
+    this.assertInitialized();
+    const serialized: string[] = [
+      addHexPrefix(this.data.length.toString(16)),
+      ...this.data.flatMap((bytes31) => bytes31.toApiRequest()),
+      ...this.pending_word.toApiRequest(),
+      ...this.pending_word_len.toApiRequest(),
+    ];
+    return computeHashOnElements(serialized);
   }
 
   /**

--- a/src/utils/hash/classHash/pedersen.ts
+++ b/src/utils/hash/classHash/pedersen.ts
@@ -13,30 +13,13 @@ import { toHex } from '../../num';
 import { encodeShortString } from '../../shortString';
 import { isString } from '../../typed';
 import { formatSpaces, nullSkipReplacer } from './util';
+import {
+  computePedersenHash,
+  computeHashOnElements,
+  computePedersenHashOnElements,
+} from '../pedersenCore';
 
-export function computePedersenHash(a: BigNumberish, b: BigNumberish): string {
-  return starkCurve.pedersen(BigInt(a), BigInt(b));
-}
-
-/**
- * Compute Pedersen hash from data
- *
- * @param {BigNumberish[]} data Array of data to compute Pedersen hash on
- * @returns {string} hex-string of Pedersen hash
- *
- * @example
- * ```typescript
- * const result = hash.computeHashOnElements(['0xabc', '0x123', '0xabc123'])
- * // result = 0x148141e8f7db29d005a0187669a56f0790d7e8c2c5b2d780e4d8b9e436a5521
- * ```
- */
-export function computeHashOnElements(data: BigNumberish[]): string {
-  return [...data, data.length]
-    .reduce((x: BigNumberish, y: BigNumberish) => starkCurve.pedersen(BigInt(x), BigInt(y)), 0)
-    .toString();
-}
-
-export const computePedersenHashOnElements = computeHashOnElements;
+export { computePedersenHash, computeHashOnElements, computePedersenHashOnElements };
 
 /**
  * Calculate contract address from class hash

--- a/src/utils/hash/pedersenCore.ts
+++ b/src/utils/hash/pedersenCore.ts
@@ -1,0 +1,29 @@
+/**
+ * Pure Pedersen hash utilities — no calldata dependency
+ */
+import { BigNumberish } from '../../types';
+import { starkCurve } from '../ec';
+
+export function computePedersenHash(a: BigNumberish, b: BigNumberish): string {
+  return starkCurve.pedersen(BigInt(a), BigInt(b));
+}
+
+/**
+ * Compute Pedersen hash from data
+ *
+ * @param {BigNumberish[]} data Array of data to compute Pedersen hash on
+ * @returns {string} hex-string of Pedersen hash
+ *
+ * @example
+ * ```typescript
+ * const result = hash.computeHashOnElements(['0xabc', '0x123', '0xabc123'])
+ * // result = 0x148141e8f7db29d005a0187669a56f0790d7e8c2c5b2d780e4d8b9e436a5521
+ * ```
+ */
+export function computeHashOnElements(data: BigNumberish[]): string {
+  return [...data, data.length]
+    .reduce((x: BigNumberish, y: BigNumberish) => starkCurve.pedersen(BigInt(x), BigInt(y)), 0)
+    .toString();
+}
+
+export const computePedersenHashOnElements = computeHashOnElements;


### PR DESCRIPTION
## Motivation and Resolution

`CairoByteArray` lacked a `hash()` method to compute the Pedersen hash of a ByteArray value on the JavaScript side, following OpenZeppelin's `hash_byte_array` algorithm. This is needed when a contract expects a hashed ByteArray (e.g. for typed-data or storage keys) without requiring an on-chain call.

Implementing `hash()` directly inside `byteArray.ts` created a circular dependency: `byteArray.ts` → `hash/classHash/pedersen.ts` → `calldata/` → `byteArray.ts`. This is resolved by extracting the pure Pedersen hash utilities (`computePedersenHash`, `computeHashOnElements`, `computePedersenHashOnElements`) into a new `src/utils/hash/pedersenCore.ts` file that carries no calldata dependency. `classHash/pedersen.ts` re-exports the three functions unchanged, so the public API is unaffected.

### RPC version (if applicable)

N/A

## Usage related changes

- New method `CairoByteArray.hash(): string` — computes the Pedersen hash of a ByteArray following OZ's `hash_byte_array` algorithm and returns a `0x`-prefixed hex felt252 string.

```typescript
const ba = new CairoByteArray('Hello');
const h = ba.hash();
// h = '0x15d19ad651ffaf8e90a13938db2081fa3ff01de0712e00cbe69891bace66c51'
```

## Development related changes

- New internal module `src/utils/hash/pedersenCore.ts` — pure Pedersen hash utilities with no calldata dependency, used by `byteArray.ts` to break a circular import.
- `src/utils/hash/classHash/pedersen.ts` now re-exports from `pedersenCore.ts` instead of defining the functions locally (no public API change).
- Unit tests added for `CairoByteArray.hash()` covering: empty string, short string (pending word only), exactly 31-byte string (one full data chunk), multi-chunk string, and error on uninitialized instance.

## Checklist:

- [x] Performed a self-review of the code
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing

