### PR TITLE
fix: plugins methods in Account not available in .d.ts

### DIFF
--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -91,6 +91,16 @@ import { defaultDeployer, Deployer } from '../deployer';
 import type { TipType } from '../provider/modules/tip';
 import { PluginManager } from '../plugins/manager';
 import { defaultPlugins } from '../plugins/defaults';
+import type { StarknetIdAccountMethods } from '../plugins/starknet-id';
+import type { BrotherIdProviderMethods } from '../plugins/brother-id';
+import type { FastExecuteAccountMethods } from '../plugins/fast-execute';
+
+// Same-module declaration merging surfaces the default plugin methods on the
+// Account type. This must live here (next to the class) rather than in a
+// `declare module '../account/default'` block, because cross-module augmentation
+// with relative paths does not survive the bundled `.d.ts` emitted by tsup.
+export interface Account
+  extends StarknetIdAccountMethods, BrotherIdProviderMethods, FastExecuteAccountMethods {}
 
 export class Account implements AccountInterface {
   public provider: Provider;

--- a/src/plugins/augmentations.ts
+++ b/src/plugins/augmentations.ts
@@ -1,13 +1,13 @@
-import type { StarknetIdProviderMethods, StarknetIdAccountMethods } from './starknet-id';
-import type { BrotherIdProviderMethods } from './brother-id';
+// Default plugin methods are surfaced on the public `RpcProvider` and `Account`
+// types via same-module declaration merging, declared directly next to each
+// class:
+//   - src/provider/rpc.ts      -> interface RpcProvider extends ...ProviderMethods
+//   - src/account/default.ts   -> interface Account extends ...AccountMethods
+//
+// This replaces the previous `declare module '../provider/rpc'` /
+// `declare module '../account/default'` augmentations: cross-module
+// augmentation with relative paths is erased when tsup bundles every `.d.ts`
+// into a single declaration file, so the methods were invisible to consumers
+// of the published package.
 
-// Module augmentation to ensure default plugin methods are visible on
-// RpcProvider and Account types without requiring explicit `.use()` calls.
-
-declare module '../provider/rpc' {
-  interface RpcProvider extends StarknetIdProviderMethods, BrotherIdProviderMethods {}
-}
-
-declare module '../account/default' {
-  interface Account extends StarknetIdAccountMethods, BrotherIdProviderMethods {}
-}
+export {};

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -59,6 +59,16 @@ import { getGasPrices } from './modules';
 import { PluginManager } from '../plugins/manager';
 import { defaultPlugins } from '../plugins/defaults';
 import type { StarknetPlugin } from '../plugins/types';
+import type { StarknetIdProviderMethods } from '../plugins/starknet-id';
+import type { BrotherIdProviderMethods } from '../plugins/brother-id';
+import type { FastExecuteProviderMethods } from '../plugins/fast-execute';
+
+// Same-module declaration merging surfaces the default plugin methods on the
+// RpcProvider type. This must live here (next to the class) rather than in a
+// `declare module '../provider/rpc'` block, because cross-module augmentation
+// with relative paths does not survive the bundled `.d.ts` emitted by tsup.
+export interface RpcProvider
+  extends StarknetIdProviderMethods, BrotherIdProviderMethods, FastExecuteProviderMethods {}
 
 export class RpcProvider implements ProviderInterface {
   public responseParser: RPCResponseParser;


### PR DESCRIPTION
## Motivation and Resolution

The default plugin methods (`starknetId`, `brotherId`, `fastExecute`) are attached
at runtime via `Object.assign` in `PluginManager`, but they were **invisible to
TypeScript consumers** of the published package. Calling `account.getStarkName()`
or `account.fastExecute()` produced `TS2339: Property '...' does not exist on type
'Account'`, even though the calls work at runtime.

Root cause: the method types were surfaced through `declare module '../provider/rpc'`
and `declare module '../account/default'` augmentations using **relative paths**.
When `tsup` (`rollup-plugin-dts`) bundles every `.d.ts` into a single declaration
file, `Account`/`RpcProvider` become top-level `declare class` declarations, so the
relative-path module augmentations point at modules that no longer exist and merge
with nothing. As a result **all** default plugin methods were missing from the
published types. The `fastExecute` plugin types were additionally never listed in
the augmentation at all.

Resolution: replace the cross-module augmentation with **same-module declaration
merging** — an `interface` of the same name as the class, declared next to the
class in `src/provider/rpc.ts` and `src/account/default.ts`. This pattern survives
the bundled `.d.ts` emitted by tsup. The missing `FastExecute*Methods` interfaces
are now included. Subclasses (`WalletAccount`, `WalletAccountV5`) inherit the merged
methods automatically.

### RPC version (if applicable)

N/A

## Usage related changes

- TypeScript users can now call default plugin methods directly on `Account`,
  `RpcProvider` and their subclasses (`WalletAccount`, `WalletAccountV5`) without
  type errors: `account.getStarkName()`, `account.getAddressFromStarkName()`,
  `account.getStarkProfile()`, `account.fastExecute()`,
  `provider.fastWaitForTransaction()`, etc.
- No runtime behavior change — methods already existed at runtime; only the
  published `.d.ts` is fixed.

## Development related changes

- Replaced the broken relative-path `declare module` augmentations in
  `src/plugins/augmentations.ts` with same-module declaration merging next to the
  `RpcProvider` and `Account` class declarations.
- Added the previously-missing `FastExecuteProviderMethods` / `FastExecuteAccountMethods`
  to the surfaced plugin method types.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
