### PR TITLE
ci: migrate actions off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -20,10 +20,10 @@ jobs:
     name: Run release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: lts/*
           cache: 'npm'

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -49,8 +49,8 @@ jobs:
       TEST_ACCOUNT_ADDRESS: ${{ secrets.TEST_ACCOUNT_ADDRESS }}
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: lts/*
           cache: 'npm'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/manual-docs-deploy-pages.yml
+++ b/.github/workflows/manual-docs-deploy-pages.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     environment: github-pages
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: develop
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: lts/*
           cache: 'npm'
@@ -54,4 +54,4 @@ jobs:
     steps:
       - name: deploy
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/manual-docs-version-pr.yml
+++ b/.github/workflows/manual-docs-version-pr.yml
@@ -33,7 +33,7 @@ jobs:
           git add www/versioned_docs www/versioned_sidebars www/versions.json
           git checkout .
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           branch: ci/docs-version
           committer: CI <noreply@github.com>

--- a/.github/workflows/manual-docs-version-pr.yml
+++ b/.github/workflows/manual-docs-version-pr.yml
@@ -11,8 +11,8 @@ jobs:
     name: Documentation build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: lts/*
           cache: 'npm'
@@ -33,7 +33,7 @@ jobs:
           git add www/versioned_docs www/versioned_sidebars www/versions.json
           git checkout .
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           branch: ci/docs-version
           committer: CI <noreply@github.com>

--- a/.github/workflows/manual-npm-dist-tag.yml
+++ b/.github/workflows/manual-npm-dist-tag.yml
@@ -14,7 +14,7 @@ jobs:
   promote:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: lts/*
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/manual-tests-testnet.yml
+++ b/.github/workflows/manual-tests-testnet.yml
@@ -49,7 +49,7 @@ jobs:
       matrix: ${{ steps.process-inputs.outputs.result }}
     steps:
       - id: process-inputs
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             // console.log(context)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,25 +37,19 @@ on:
       - 'ts*'
       - '!www/**'
 
-jobs:
-  skip_check:
-    name: Skip check
-    if: github.event_name != 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    outputs:
-      should_skip: ${{ steps.skip_duplicate.outputs.should_skip }}
-    steps:
-      - id: skip_duplicate
-        uses: fkirc/skip-duplicate-actions@v5
-        with:
-          cancel_others: 'true'
+# Cancel redundant in-progress runs for the same ref (replaces the
+# `cancel_others` behaviour of the now-unmaintained skip-duplicate-actions).
+# Scoped to pull_request only: a push to a release branch is never cancelled,
+# so an in-flight publish can never be interrupted by a newer push.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+jobs:
   tests-dev:
     name: Run test on ${{ matrix.name }}
-    needs: [skip_check]
     if: |
       github.event_name != 'workflow_dispatch'
-      && needs.skip_check.outputs.should_skip != 'true'
       && contains(fromJSON('["beta","develop","next-version"]'), github.base_ref || github.ref_name)
     strategy:
       fail-fast: false
@@ -72,10 +66,8 @@ jobs:
 
   tests-main:
     name: Run test on ${{ matrix.node }} ${{ matrix.protocol }} ${{ matrix.version }}
-    needs: [skip_check]
     if: |
       github.event_name != 'workflow_dispatch'
-      && needs.skip_check.outputs.should_skip != 'true'
       && (github.base_ref || github.ref_name) == 'main'
     strategy:
       max-parallel: 1
@@ -94,19 +86,14 @@ jobs:
 
   release-auto:
     name: Release
-    needs: [skip_check, tests-dev, tests-main]
-    # NOTE: intentionally NOT gated on `skip_check.outputs.should_skip`.
-    # skip-duplicate-actions skips the *test* jobs when an identical file tree was
-    # already validated (e.g. in the PR build). Releasing is a different concern and
-    # must still run on a push to a release branch, otherwise a merge whose tree
-    # matches the PR build silently cancels the publish. `always() && !failure()`
-    # lets the release proceed when tests are skipped, while still blocking it if a
-    # test job actually fails. semantic-release is idempotent (no version bump =
-    # no publish), so running it on a duplicate push is safe.
+    needs: [tests-dev, tests-main]
+    # `always() && !failure()` lets the release proceed even when a test job is
+    # skipped (e.g. tests-main is skipped on non-`main` branches), while still
+    # blocking it if a test job actually fails. semantic-release is idempotent
+    # (no version bump = no publish), so running it on a duplicate push is safe.
     if: |
       always()
       && !failure()
-      && needs.skip_check.result != 'failure'
       && github.event_name == 'push'
     uses: ./.github/workflows/_release.yml
     secrets: inherit


### PR DESCRIPTION
## Motivation and Resolution
GitHub Actions is retiring the Node 20 action runtime. Per the [official
changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/),
actions still declaring `runs.using: node20` are forced onto Node 24 on
**2026-06-16** and Node 20 is **removed from runners on 2026-09-16**. The
trigger for this PR was `fkirc/skip-duplicate-actions@v5` surfacing the
deprecation warning in our CI logs.

An audit of every workflow found all JavaScript actions still on `node20`.
The riskiest one is `fkirc/skip-duplicate-actions`: it is unmaintained
(last release v5.3.1 in Oct 2023, last commit Oct 2024) and has **no
node24 release**, so it cannot simply be bumped.

Resolution:

- **`release.yml` — drop `fkirc/skip-duplicate-actions@v5`.** Its two roles
  are handled natively:
  - `cancel_others: true` → replaced by a native `concurrency` block,
    scoped to `pull_request` only so a release push is never cancelled
    mid-publish (an improvement over the previous behaviour).
  - `should_skip` (skip test jobs when an identical file tree was already
    validated) → dropped. The existing `paths:` filters already cover the
    common "nothing testable changed" case; the residual cost is at most a
    redundant test run after merge, never a correctness risk. This also
    follows up on commit `95381023`, which already decoupled the release
    job from `should_skip`.
- **Bump remaining `node20` actions to their `node24` majors:**
  | Action | From | To |
  | --- | --- | --- |
  | `actions/checkout` | v4 | v5 |
  | `actions/setup-node` | v4 | v5 |
  | `actions/github-script` | v7 | v8 |
  | `actions/deploy-pages` | v4 | v5 |
  | `peter-evans/create-pull-request` | v6 | v8 |

Left intentionally unchanged:

- `actions/upload-pages-artifact@v3` — transitively `node20` via
  `actions/upload-artifact` (still `node20` even at v5). It is
  GitHub-maintained and not yet migrated upstream; bumping it changes
  nothing.
- `github/codeql-action@v4` — already on `node24`.

### RPC version (if applicable)
N/A 

## Usage related changes
- None. No public API, runtime, or packaging change for SDK users.

## Development related changes
- CI no longer depends on the unmaintained `fkirc/skip-duplicate-actions`;
  concurrent runs are now cancelled via a native `concurrency` block.
- All workflow actions now run on the Node 24 action runtime, ahead of the
  2026-06-16 GitHub enforcement.
- Validated locally: YAML parse + `actionlint` (0 errors across 6 affected
  workflows).

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] All tests are passing
