### PR TITLE
fix: surface clear error instead of crashing on empty node reply

### DIFF
--- a/__tests__/rpcChannel010.test.ts
+++ b/__tests__/rpcChannel010.test.ts
@@ -306,4 +306,31 @@ describe('UNIT TEST: RPC 0.10.1 Channel - New API features', () => {
       expect(result).not.toHaveProperty('proof_facts');
     });
   });
+
+  describe('malformed RPC response', () => {
+    test('throws a clear error when response has neither result nor error', async () => {
+      // Reproduces issue #1238: a node (e.g. Alchemy returning 404) replies with a
+      // body that is missing both `result` and `error`. Previously this returned
+      // `undefined` and crashed downstream with `response.flat is not a function`.
+      fetchSpy = jest.spyOn(channel, 'fetch');
+      fetchSpy.mockResolvedValueOnce({
+        json: async () => ({ jsonrpc: '2.0', id: 1 }),
+      } as any);
+
+      await expect((channel as any).fetchEndpoint('starknet_chainId')).rejects.toThrow(
+        LibraryError
+      );
+    });
+
+    test('preserves a falsy but valid result (genesis block number 0)', async () => {
+      // Guards against the naive `if (!result)` check: 0 is a legitimate Starknet
+      // result (e.g. genesis block number) and must be returned, not treated as an error.
+      fetchSpy = jest.spyOn(channel, 'fetch');
+      fetchSpy.mockResolvedValueOnce({
+        json: async () => ({ jsonrpc: '2.0', result: 0, id: 1 }),
+      } as any);
+
+      await expect((channel as any).fetchEndpoint('starknet_blockNumber')).resolves.toBe(0);
+    });
+  });
 });

--- a/__tests__/rpcChannel09.test.ts
+++ b/__tests__/rpcChannel09.test.ts
@@ -63,6 +63,21 @@ describeIfRpc09ForTesting('UNIT TEST: RPC 0.9.0 Channel', () => {
     fetchSpy.mockRestore();
   });
 
+  test('throws a clear error when response has neither result nor error', async () => {
+    // Issue #1238: a malformed/empty reply (no result, no error) must throw a
+    // LibraryError instead of silently returning undefined.
+    const fetchSpy = jest.spyOn(channel09, 'fetch');
+    fetchSpy.mockResolvedValueOnce({
+      json: async () => ({ jsonrpc: '2.0', id: 1 }),
+    } as any);
+
+    await expect(
+      // @ts-expect-error private method accessed for testing
+      channel09.fetchEndpoint('starknet_chainId')
+    ).rejects.toThrow(LibraryError);
+    fetchSpy.mockRestore();
+  });
+
   describe('RPC 0.9.0 specific methods', () => {
     test('getBlockWithReceipts', async () => {
       const response = await channel09.getBlockWithReceipts('latest');

--- a/src/channel/rpc_0_10_2.ts
+++ b/src/channel/rpc_0_10_2.ts
@@ -173,19 +173,22 @@ export class RpcChannel {
     params?: RPC.Methods[T]['params']
   ): Promise<RPC.Methods[T]['result']> {
     try {
+      let error: JRPC.Error | undefined;
+      let result: RPC.Methods[T]['result'] | undefined;
       if (this.batchClient) {
-        const { error, result } = await this.batchClient.fetch(
-          method,
-          params,
-          (this.requestId += 1)
-        );
-        this.errorHandler(method, params, error);
-        return result as RPC.Methods[T]['result'];
+        ({ error, result } = await this.batchClient.fetch(method, params, (this.requestId += 1)));
+      } else {
+        const rawResult = await this.fetch(method, params, (this.requestId += 1));
+        ({ error, result } = await rawResult.json());
       }
-
-      const rawResult = await this.fetch(method, params, (this.requestId += 1));
-      const { error, result } = await rawResult.json();
       this.errorHandler(method, params, error);
+      if (result === undefined) {
+        // No `error` and no `result`: the node reply is malformed or not a valid
+        // JSON-RPC response (e.g. an HTTP 404 from a misconfigured node URL). See issue #1238.
+        throw new LibraryError(
+          `RPC: '${method}' returned an empty response (no result and no error). The node reply is malformed or not a valid JSON-RPC response.`
+        );
+      }
       return result as RPC.Methods[T]['result'];
     } catch (error: any) {
       this.errorHandler(method, params, error?.response?.data, error);

--- a/src/channel/rpc_0_9_0.ts
+++ b/src/channel/rpc_0_9_0.ts
@@ -174,19 +174,22 @@ export class RpcChannel {
     params?: RPC.Methods[T]['params']
   ): Promise<RPC.Methods[T]['result']> {
     try {
+      let error: JRPC.Error | undefined;
+      let result: RPC.Methods[T]['result'] | undefined;
       if (this.batchClient) {
-        const { error, result } = await this.batchClient.fetch(
-          method,
-          params,
-          (this.requestId += 1)
-        );
-        this.errorHandler(method, params, error);
-        return result as RPC.Methods[T]['result'];
+        ({ error, result } = await this.batchClient.fetch(method, params, (this.requestId += 1)));
+      } else {
+        const rawResult = await this.fetch(method, params, (this.requestId += 1));
+        ({ error, result } = await rawResult.json());
       }
-
-      const rawResult = await this.fetch(method, params, (this.requestId += 1));
-      const { error, result } = await rawResult.json();
       this.errorHandler(method, params, error);
+      if (result === undefined) {
+        // No `error` and no `result`: the node reply is malformed or not a valid
+        // JSON-RPC response (e.g. an HTTP 404 from a misconfigured node URL). See issue #1238.
+        throw new LibraryError(
+          `RPC: '${method}' returned an empty response (no result and no error). The node reply is malformed or not a valid JSON-RPC response.`
+        );
+      }
       return result as RPC.Methods[T]['result'];
     } catch (error: any) {
       this.errorHandler(method, params, error?.response?.data, error);


### PR DESCRIPTION
## Motivation and Resolution
Addresses the actionable part of #1238. The original trigger (Alchemy returning a `404` without an API key) was a provider-side change and is no longer reproducible. The valid underlying problem remains: when a node replies with **neither `result` nor `error`** (malformed or non-JSON-RPC response), `fetchEndpoint` silently returned `undefined`, crashing downstream with the cryptic `TypeError: response.flat is not a function`.

`fetchEndpoint` now throws an explicit `LibraryError` (naming the RPC method) when the response is empty/malformed. Detection is structural — only when both `result` and `error` are absent — so falsy-but-valid results (e.g. genesis block number `0`) are preserved.

### RPC version (if applicable)
Applies to both the RPC `0.9` and `0.10.x` channels.

## Usage related changes

- A malformed/empty node reply now raises a clear `LibraryError` naming the failed RPC method, instead of an obscure `response.flat is not a function` crash further down the stack.

## Development related changes

- Added unit tests for the empty/malformed response case (throws `LibraryError`) and for the falsy-but-valid `result: 0` case (returned as-is).

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
