### PR TITLE
fix: avoid extra waitForTransaction receipt delay

### DIFF
--- a/__tests__/rpcChannel010.test.ts
+++ b/__tests__/rpcChannel010.test.ts
@@ -74,6 +74,41 @@ describe('UNIT TEST: RPC 0.10.1 Channel - New API features', () => {
     fetchSpy?.mockRestore();
   });
 
+  describe('waitForTransaction', () => {
+    test('returns immediately after the receipt is available', async () => {
+      jest.useFakeTimers();
+      const receipt = { transaction_hash: '0x123' };
+      const transactionStatusSpy = jest
+        .spyOn(channel, 'getTransactionStatus')
+        .mockResolvedValueOnce({
+          finality_status: 'ACCEPTED_ON_L2',
+          execution_status: 'SUCCEEDED',
+        });
+      const transactionReceiptSpy = jest
+        .spyOn(channel, 'getTransactionReceipt')
+        .mockResolvedValueOnce(receipt as any);
+
+      const promise = channel.waitForTransaction('0x123', { retryInterval: 1_000 });
+      let settled = false;
+      const settledPromise = promise.then((result) => {
+        settled = true;
+        return result;
+      });
+
+      try {
+        await jest.advanceTimersByTimeAsync(1_000);
+        await Promise.resolve();
+
+        expect(settled).toBe(true);
+        await expect(settledPromise).resolves.toBe(receipt);
+      } finally {
+        transactionStatusSpy.mockRestore();
+        transactionReceiptSpy.mockRestore();
+        jest.useRealTimers();
+      }
+    });
+  });
+
   describe('response_flags (includeProofFacts)', () => {
     test('getBlockWithTxs with includeProofFacts sends response_flags', async () => {
       fetchSpy = jest.spyOn(channel, 'fetch');

--- a/__tests__/rpcChannel010.test.ts
+++ b/__tests__/rpcChannel010.test.ts
@@ -107,6 +107,49 @@ describe('UNIT TEST: RPC 0.10.1 Channel - New API features', () => {
         jest.useRealTimers();
       }
     });
+
+    test('waits one retry interval when the receipt is not available yet', async () => {
+      jest.useFakeTimers();
+      const receipt = { transaction_hash: '0x123' };
+      const transactionStatusSpy = jest
+        .spyOn(channel, 'getTransactionStatus')
+        .mockResolvedValueOnce({
+          finality_status: 'ACCEPTED_ON_L2',
+          execution_status: 'SUCCEEDED',
+        });
+      const transactionReceiptSpy = jest
+        .spyOn(channel, 'getTransactionReceipt')
+        .mockRejectedValueOnce(new Error('Transaction hash not found'))
+        .mockResolvedValueOnce(receipt as any);
+
+      const promise = channel.waitForTransaction('0x123', { retryInterval: 1_000 });
+      let settled = false;
+      const settledPromise = promise.then((result) => {
+        settled = true;
+        return result;
+      });
+
+      try {
+        // status polling interval elapsed, first receipt attempt rejected
+        await jest.advanceTimersByTimeAsync(1_000);
+        expect(transactionReceiptSpy).toHaveBeenCalledTimes(1);
+        expect(settled).toBe(false);
+
+        // pacing between two receipt attempts is preserved
+        await jest.advanceTimersByTimeAsync(999);
+        expect(transactionReceiptSpy).toHaveBeenCalledTimes(1);
+        expect(settled).toBe(false);
+
+        await jest.advanceTimersByTimeAsync(1);
+        expect(transactionReceiptSpy).toHaveBeenCalledTimes(2);
+        expect(settled).toBe(true);
+        await expect(settledPromise).resolves.toBe(receipt);
+      } finally {
+        transactionStatusSpy.mockRestore();
+        transactionReceiptSpy.mockRestore();
+        jest.useRealTimers();
+      }
+    });
   });
 
   describe('response_flags (includeProofFacts)', () => {

--- a/__tests__/rpcChannel09.test.ts
+++ b/__tests__/rpcChannel09.test.ts
@@ -197,3 +197,42 @@ describeIfRpc09ForTesting('UNIT TEST: RPC 0.9.0 Channel', () => {
     });
   });
 });
+
+describe('UNIT TEST: RPC 0.9.0 Channel waitForTransaction', () => {
+  let channel: RPC09.RpcChannel;
+
+  beforeEach(() => {
+    channel = new RPC09.RpcChannel({ nodeUrl: 'http://localhost:5050/rpc' });
+  });
+
+  test('returns immediately after the receipt is available', async () => {
+    jest.useFakeTimers();
+    const receipt = { transaction_hash: '0x123' };
+    const transactionStatusSpy = jest.spyOn(channel, 'getTransactionStatus').mockResolvedValueOnce({
+      finality_status: 'ACCEPTED_ON_L2',
+      execution_status: 'SUCCEEDED',
+    });
+    const transactionReceiptSpy = jest
+      .spyOn(channel, 'getTransactionReceipt')
+      .mockResolvedValueOnce(receipt as any);
+
+    const promise = channel.waitForTransaction('0x123', { retryInterval: 1_000 });
+    let settled = false;
+    const settledPromise = promise.then((result) => {
+      settled = true;
+      return result;
+    });
+
+    try {
+      await jest.advanceTimersByTimeAsync(1_000);
+      await Promise.resolve();
+
+      expect(settled).toBe(true);
+      await expect(settledPromise).resolves.toBe(receipt);
+    } finally {
+      transactionStatusSpy.mockRestore();
+      transactionReceiptSpy.mockRestore();
+      jest.useRealTimers();
+    }
+  });
+});

--- a/__tests__/rpcChannel09.test.ts
+++ b/__tests__/rpcChannel09.test.ts
@@ -235,4 +235,45 @@ describe('UNIT TEST: RPC 0.9.0 Channel waitForTransaction', () => {
       jest.useRealTimers();
     }
   });
+
+  test('waits one retry interval when the receipt is not available yet', async () => {
+    jest.useFakeTimers();
+    const receipt = { transaction_hash: '0x123' };
+    const transactionStatusSpy = jest.spyOn(channel, 'getTransactionStatus').mockResolvedValueOnce({
+      finality_status: 'ACCEPTED_ON_L2',
+      execution_status: 'SUCCEEDED',
+    });
+    const transactionReceiptSpy = jest
+      .spyOn(channel, 'getTransactionReceipt')
+      .mockRejectedValueOnce(new Error('Transaction hash not found'))
+      .mockResolvedValueOnce(receipt as any);
+
+    const promise = channel.waitForTransaction('0x123', { retryInterval: 1_000 });
+    let settled = false;
+    const settledPromise = promise.then((result) => {
+      settled = true;
+      return result;
+    });
+
+    try {
+      // status polling interval elapsed, first receipt attempt rejected
+      await jest.advanceTimersByTimeAsync(1_000);
+      expect(transactionReceiptSpy).toHaveBeenCalledTimes(1);
+      expect(settled).toBe(false);
+
+      // pacing between two receipt attempts is preserved
+      await jest.advanceTimersByTimeAsync(999);
+      expect(transactionReceiptSpy).toHaveBeenCalledTimes(1);
+      expect(settled).toBe(false);
+
+      await jest.advanceTimersByTimeAsync(1);
+      expect(transactionReceiptSpy).toHaveBeenCalledTimes(2);
+      expect(settled).toBe(true);
+      await expect(settledPromise).resolves.toBe(receipt);
+    } finally {
+      transactionStatusSpy.mockRestore();
+      transactionReceiptSpy.mockRestore();
+      jest.useRealTimers();
+    }
+  });
 });

--- a/src/channel/rpc_0_10_2.ts
+++ b/src/channel/rpc_0_10_2.ts
@@ -569,10 +569,10 @@ export class RpcChannel {
         if (retries <= 0) {
           throw new Error(`waitForTransaction timed-out with retries ${this.retries}`);
         }
+        // eslint-disable-next-line no-await-in-loop
+        await wait(retryInterval);
       }
       retries -= 1;
-      // eslint-disable-next-line no-await-in-loop
-      await wait(retryInterval);
     }
     return txReceipt as RPC.TXN_RECEIPT;
   }

--- a/src/channel/rpc_0_10_2.ts
+++ b/src/channel/rpc_0_10_2.ts
@@ -569,10 +569,10 @@ export class RpcChannel {
         if (retries <= 0) {
           throw new Error(`waitForTransaction timed-out with retries ${this.retries}`);
         }
+        retries -= 1;
         // eslint-disable-next-line no-await-in-loop
         await wait(retryInterval);
       }
-      retries -= 1;
     }
     return txReceipt as RPC.TXN_RECEIPT;
   }

--- a/src/channel/rpc_0_9_0.ts
+++ b/src/channel/rpc_0_9_0.ts
@@ -485,10 +485,10 @@ export class RpcChannel {
         if (retries <= 0) {
           throw new Error(`waitForTransaction timed-out with retries ${this.retries}`);
         }
+        // eslint-disable-next-line no-await-in-loop
+        await wait(retryInterval);
       }
       retries -= 1;
-      // eslint-disable-next-line no-await-in-loop
-      await wait(retryInterval);
     }
     return txReceipt as RPC.TXN_RECEIPT;
   }

--- a/src/channel/rpc_0_9_0.ts
+++ b/src/channel/rpc_0_9_0.ts
@@ -485,10 +485,10 @@ export class RpcChannel {
         if (retries <= 0) {
           throw new Error(`waitForTransaction timed-out with retries ${this.retries}`);
         }
+        retries -= 1;
         // eslint-disable-next-line no-await-in-loop
         await wait(retryInterval);
       }
-      retries -= 1;
     }
     return txReceipt as RPC.TXN_RECEIPT;
   }


### PR DESCRIPTION
Fixes #1632

## Summary
- Remove the unconditional post-receipt polling delay from `waitForTransaction`
- Preserve retry pacing when `getTransactionReceipt` is not ready yet
- Apply the fix to both RPC 0.9 and RPC 0.10 channel implementations
- Add regression tests proving successful receipt availability resolves without another polling interval

## Validation
- `npx jest __tests__/rpcChannel010.test.ts __tests__/rpcChannel09.test.ts --runInBand --testNamePattern "returns immediately" --config '{"transform":{"^.+\\\\.(t|j)sx?$":"@swc/jest"},"testEnvironment":"node","setupFilesAfterEnv":["./__tests__/config/jest.setup.ts"]}'`
- `npx eslint src/channel/rpc_0_10_2.ts src/channel/rpc_0_9_0.ts __tests__/rpcChannel010.test.ts __tests__/rpcChannel09.test.ts`
- `npm run ts:check`
- `git diff --check origin/main...HEAD`