### PR TITLE
docs:  add meta tag for algolia searchDoc verification

### DIFF
--- a/www/docusaurus.config.ts
+++ b/www/docusaurus.config.ts
@@ -188,6 +188,15 @@ const config: Config = {
   },
   onBrokenLinks: 'throw',
   favicon: 'img/favicon.ico',
+  headTags: [
+    {
+      tagName: 'meta',
+      attributes: {
+        name: 'algolia-site-verification',
+        content: '0F4C4F228CB73707',
+      },
+    },
+  ],
   organizationName: 'starknet-io', // Usually your GitHub org/user name.
   projectName: 'starknet.js', // Usually your repo name.
   presets: [


### PR DESCRIPTION
## Motivation and Resolution

The documentation site URL has changed. Algolia requires domain ownership verification to allow the crawler to index the new URL.

This PR adds the Algolia verification meta tag to the Docusaurus head configuration so that the domain can be verified without adding a dedicated HTML file to the static assets.

### RPC version (if applicable)

N/A

## Usage related changes

- None (documentation site infrastructure only).

## Development related changes

- Added `headTags` entry in `www/docusaurus.config.ts` to inject the `algolia-site-verification` meta tag on every page of the documentation site.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] All tests are passing
