### PR TITLE
docs: add Ask AI support

### DIFF
--- a/www/docusaurus.config.ts
+++ b/www/docusaurus.config.ts
@@ -233,6 +233,12 @@ const config: Config = {
 
       indexName: 'starknetjs',
 
+      // Algolia "Ask AI" conversational assistant (DocSearch v4).
+      // The assistantId is a public value (configured in the Algolia dashboard,
+      // LLM provider: Google Gemini). indexName/apiKey/appId are inherited from
+      // the options above.
+      askAi: 'f949afac-da08-4698-82a3-a22b60af6fd3',
+
       // Optional: see doc section below
       contextualSearch: true,
 

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -8,6 +8,7 @@
       "name": "www",
       "version": "0.0.0",
       "dependencies": {
+        "@docsearch/react": "^4.6.3",
         "@docusaurus/core": "3.10.1",
         "@docusaurus/plugin-content-docs": "3.10.1",
         "@docusaurus/preset-classic": "3.10.1",

--- a/www/package.json
+++ b/www/package.json
@@ -16,6 +16,7 @@
     "typecheck": "tsc"
   },
   "dependencies": {
+    "@docsearch/react": "^4.6.3",
     "@docusaurus/core": "3.10.1",
     "@docusaurus/plugin-content-docs": "3.10.1",
     "@docusaurus/preset-classic": "3.10.1",


### PR DESCRIPTION
## Motivation and Resolution

Adds Algolia's **Ask AI** conversational assistant on top of the existing
DocSearch integration in the Docusaurus documentation site. Users can now ask
natural-language questions in the search modal and get answers grounded in the
starknet.js documentation, in addition to the classic keyword search.

Ask AI is a DocSearch v4 feature. Docusaurus 3.10.1 already supports it
natively (the `@docusaurus/theme-search-algolia` theme accepts an `askAi`
option and renders the Ask AI UI), so the integration is config-only: no
component swizzle is required. The only requirement is that the search bar runs
on DocSearch v4.

The assistant itself is configured in the Algolia dashboard (Generative AI /
Agent Studio), backed by an LLM provider. The `assistantId` referenced in the
config is a public value, like the existing public search `apiKey`.

### RPC version (if applicable)

Not applicable — documentation-only change.

## Usage related changes

- The documentation search modal now offers an **Ask AI** conversational mode
  alongside the existing keyword search.

## Development related changes

- Added `@docsearch/react@^4.6.3` as a direct dependency of `www/` to ensure
  the search bar resolves DocSearch v4 (required for Ask AI). The
  `@docusaurus/theme-search-algolia` theme natively consumes it.
- Added the `askAi` option (public `assistantId`) to the `algolia` block of
  `www/docusaurus.config.ts`.
- No secret is committed: the LLM provider API key lives only in the Algolia
  dashboard.

## Checklist:

- [x] Performed a self-review of the code
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] All tests are passing
