### PR TITLE
docs: support Algolia Agent Studio agent for Ask AI

### DIFF
--- a/www/src/theme/SearchBar/index.tsx
+++ b/www/src/theme/SearchBar/index.tsx
@@ -1,0 +1,358 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// SWIZZLED (eject) from @docusaurus/theme-search-algolia to make Algolia
+// "Ask AI" work with an Agent Studio agent.
+//
+// Two reasons the native theme is not enough:
+//  1. DocSearch v4 needs `askAi.agentStudio: true` to talk to an Agent Studio
+//     agent, and the theme config schema does not allow that field.
+//  2. With `contextualSearch: true`, the theme injects a `facetFilters`
+//     `searchParameters` into the Ask AI request, which Agent Studio rejects
+//     (its searchParameters must be keyed by index name). Keyword search keeps
+//     its contextual facetFilters; we only sanitize the Ask AI request.
+//
+// The ONLY change vs. the upstream component is the `askAiProps` block below
+// (search for "Agent Studio") and its use in the modal. Re-sync this file with
+// upstream on theme upgrades, and delete the swizzle once the theme supports
+// Agent Studio askAi natively.
+
+import React, {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import {createPortal} from 'react-dom';
+import {DocSearchButton} from '@docsearch/react/button';
+import {useDocSearchKeyboardEvents} from '@docsearch/react/useDocSearchKeyboardEvents';
+import Head from '@docusaurus/Head';
+import Link from '@docusaurus/Link';
+import {useHistory} from '@docusaurus/router';
+import {
+  isRegexpStringMatch,
+  useSearchLinkCreator,
+} from '@docusaurus/theme-common';
+import {
+  useAlgoliaContextualFacetFilters,
+  useSearchResultUrlProcessor,
+  useAlgoliaAskAi,
+  mergeFacetFilters,
+} from '@docusaurus/theme-search-algolia/client';
+import Translate from '@docusaurus/Translate';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import translations from '@theme/SearchTranslations';
+import type {
+  InternalDocSearchHit,
+  DocSearchModal as DocSearchModalType,
+  DocSearchModalProps,
+  StoredDocSearchHit,
+  DocSearchTransformClient,
+  DocSearchHit,
+  DocSearchTranslations,
+  UseDocSearchKeyboardEventsProps,
+} from '@docsearch/react';
+
+import type {AutocompleteState} from '@algolia/autocomplete-core';
+import type {FacetFilters} from 'algoliasearch/lite';
+import type {ThemeConfigAlgolia} from '@docusaurus/theme-search-algolia';
+
+type DocSearchProps = Omit<
+  DocSearchModalProps,
+  'onClose' | 'initialScrollY'
+> & {
+  contextualSearch?: string;
+  externalUrlRegex?: string;
+  searchPagePath: boolean | string;
+  askAi?: Exclude<
+    (DocSearchModalProps & {askAi: unknown})['askAi'],
+    string | undefined
+  >;
+};
+
+// extend DocSearchProps for v4 features
+// TODO Docusaurus v4: cleanup after we drop support for DocSearch v3
+interface DocSearchV4Props extends Omit<DocSearchProps, 'askAi'> {
+  indexName: string;
+  askAi?: ThemeConfigAlgolia['askAi'];
+  translations?: DocSearchTranslations;
+}
+
+let DocSearchModal: typeof DocSearchModalType | null = null;
+
+function importDocSearchModalIfNeeded() {
+  if (DocSearchModal) {
+    return Promise.resolve();
+  }
+  return Promise.all([
+    import('@docsearch/react/modal'),
+    import('@docsearch/react/style'),
+    import('./styles.css'),
+  ]).then(([{DocSearchModal: Modal}]) => {
+    DocSearchModal = Modal;
+  });
+}
+
+function useNavigator({
+  externalUrlRegex,
+}: Pick<DocSearchProps, 'externalUrlRegex'>) {
+  const history = useHistory();
+  const [navigator] = useState<DocSearchModalProps['navigator']>(() => {
+    return {
+      navigate(params) {
+        // Algolia results could contain URL's from other domains which cannot
+        // be served through history and should navigate with window.location
+        if (isRegexpStringMatch(externalUrlRegex, params.itemUrl)) {
+          window.location.href = params.itemUrl;
+        } else {
+          history.push(params.itemUrl);
+        }
+      },
+    };
+  });
+  return navigator;
+}
+
+function useTransformSearchClient(): DocSearchModalProps['transformSearchClient'] {
+  const {
+    siteMetadata: {docusaurusVersion},
+  } = useDocusaurusContext();
+  return useCallback(
+    (searchClient: DocSearchTransformClient) => {
+      searchClient.addAlgoliaAgent('docusaurus', docusaurusVersion);
+      return searchClient;
+    },
+    [docusaurusVersion],
+  );
+}
+
+function useTransformItems(props: Pick<DocSearchProps, 'transformItems'>) {
+  const processSearchResultUrl = useSearchResultUrlProcessor();
+  const [transformItems] = useState<DocSearchModalProps['transformItems']>(
+    () => {
+      return (items: DocSearchHit[]) =>
+        props.transformItems
+          ? // Custom transformItems
+            props.transformItems(items)
+          : // Default transformItems
+            items.map((item) => ({
+              ...item,
+              url: processSearchResultUrl(item.url),
+            }));
+    },
+  );
+  return transformItems;
+}
+
+function useResultsFooterComponent({
+  closeModal,
+}: {
+  closeModal: () => void;
+}): DocSearchProps['resultsFooterComponent'] {
+  return useMemo(
+    () =>
+      ({state}) =>
+        <ResultsFooter state={state} onClose={closeModal} />,
+    [closeModal],
+  );
+}
+
+function Hit({
+  hit,
+  children,
+}: {
+  hit: InternalDocSearchHit | StoredDocSearchHit;
+  children: ReactNode;
+}) {
+  return <Link to={hit.url}>{children}</Link>;
+}
+
+type ResultsFooterProps = {
+  state: AutocompleteState<InternalDocSearchHit>;
+  onClose: () => void;
+};
+
+function ResultsFooter({state, onClose}: ResultsFooterProps) {
+  const createSearchLink = useSearchLinkCreator();
+
+  return (
+    <Link to={createSearchLink(state.query)} onClick={onClose}>
+      <Translate
+        id="theme.SearchBar.seeAll"
+        values={{count: state.context.nbHits}}>
+        {'See all {count} results'}
+      </Translate>
+    </Link>
+  );
+}
+
+function useSearchParameters({
+  contextualSearch,
+  ...props
+}: DocSearchProps): DocSearchProps['searchParameters'] {
+  const contextualSearchFacetFilters = useAlgoliaContextualFacetFilters();
+
+  const configFacetFilters: FacetFilters =
+    props.searchParameters?.facetFilters ?? [];
+
+  const facetFilters: FacetFilters = contextualSearch
+    ? // Merge contextual search filters with config filters
+      mergeFacetFilters(contextualSearchFacetFilters, configFacetFilters)
+    : // ... or use config facetFilters
+      configFacetFilters;
+
+  // We let users override default searchParameters if they want to
+  return {
+    ...props.searchParameters,
+    facetFilters,
+  };
+}
+
+function DocSearch({externalUrlRegex, ...props}: DocSearchV4Props) {
+  const navigator = useNavigator({externalUrlRegex});
+  const searchParameters = useSearchParameters({...props} as DocSearchProps);
+  const transformItems = useTransformItems(props);
+  const transformSearchClient = useTransformSearchClient();
+
+  const searchContainer = useRef<HTMLDivElement | null>(null);
+  const searchButtonRef = useRef<HTMLButtonElement | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [initialQuery, setInitialQuery] = useState<string | undefined>(
+    undefined,
+  );
+
+  const {isAskAiActive, currentPlaceholder, onAskAiToggle, extraAskAiProps} =
+    useAlgoliaAskAi(props);
+
+  // Agent Studio: the Ask AI assistant is an Agent Studio agent, so it needs
+  // `agentStudio: true`, and it rejects the classic `facetFilters`
+  // searchParameters that contextualSearch injects. Enable Agent Studio and
+  // drop searchParameters from the Ask AI request (keyword search keeps its own
+  // `searchParameters` above).
+  const askAiProps = extraAskAiProps.askAi
+    ? {
+        ...extraAskAiProps,
+        askAi: {
+          ...(extraAskAiProps.askAi as object),
+          agentStudio: true,
+          searchParameters: undefined,
+        } as typeof extraAskAiProps.askAi,
+      }
+    : extraAskAiProps;
+
+  const prepareSearchContainer = useCallback(() => {
+    if (!searchContainer.current) {
+      const divElement = document.createElement('div');
+      searchContainer.current = divElement;
+      document.body.insertBefore(divElement, document.body.firstChild);
+    }
+  }, []);
+
+  const openModal = useCallback(() => {
+    prepareSearchContainer();
+    importDocSearchModalIfNeeded().then(() => setIsOpen(true));
+  }, [prepareSearchContainer]);
+
+  const closeModal = useCallback(() => {
+    setIsOpen(false);
+    searchButtonRef.current?.focus();
+    setInitialQuery(undefined);
+    onAskAiToggle(false);
+  }, [onAskAiToggle]);
+
+  const handleInput = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === 'f' && (event.metaKey || event.ctrlKey)) {
+        // ignore browser's ctrl+f
+        return;
+      }
+      // prevents duplicate key insertion in the modal input
+      event.preventDefault();
+      setInitialQuery(event.key);
+      openModal();
+    },
+    [openModal],
+  );
+
+  const resultsFooterComponent = useResultsFooterComponent({closeModal});
+
+  useDocSearchKeyboardEvents({
+    isOpen,
+    onOpen: openModal,
+    onClose: closeModal,
+    onInput: handleInput,
+    searchButtonRef,
+    isAskAiActive: isAskAiActive ?? false,
+    onAskAiToggle: onAskAiToggle ?? (() => {}),
+  } satisfies UseDocSearchKeyboardEventsProps & {
+    // TODO Docusaurus v4: cleanup after we drop support for DocSearch v3
+    isAskAiActive: boolean;
+    onAskAiToggle: (askAiToggle: boolean) => void;
+  } as UseDocSearchKeyboardEventsProps);
+
+  return (
+    <>
+      <Head>
+        {/* This hints the browser that the website will load data from Algolia,
+        and allows it to preconnect to the DocSearch cluster. It makes the first
+        query faster, especially on mobile. */}
+        <link
+          rel="preconnect"
+          href={`https://${props.appId}-dsn.algolia.net`}
+          crossOrigin="anonymous"
+        />
+      </Head>
+
+      <DocSearchButton
+        onTouchStart={importDocSearchModalIfNeeded}
+        onFocus={importDocSearchModalIfNeeded}
+        onMouseOver={importDocSearchModalIfNeeded}
+        onClick={openModal}
+        ref={searchButtonRef}
+        translations={props.translations?.button ?? translations.button}
+      />
+
+      {isOpen &&
+        DocSearchModal &&
+        searchContainer.current &&
+        createPortal(
+          <DocSearchModal
+            onClose={closeModal}
+            initialScrollY={window.scrollY}
+            initialQuery={initialQuery}
+            navigator={navigator}
+            transformItems={transformItems}
+            hitComponent={Hit}
+            transformSearchClient={transformSearchClient}
+            {...(props.searchPagePath && {
+              resultsFooterComponent,
+            })}
+            placeholder={currentPlaceholder}
+            {...(props as any)}
+            translations={props.translations?.modal ?? translations.modal}
+            searchParameters={searchParameters}
+            {...askAiProps}
+          />,
+          searchContainer.current,
+        )}
+    </>
+  );
+}
+
+export default function SearchBar(props: Partial<DocSearchV4Props>): ReactNode {
+  const {siteConfig} = useDocusaurusContext();
+
+  const docSearchProps: DocSearchV4Props = {
+    ...(siteConfig.themeConfig.algolia as DocSearchV4Props),
+    // Let props override theme config
+    // See https://github.com/facebook/docusaurus/pull/11581
+    ...props,
+  };
+
+  return <DocSearch {...docSearchProps} />;
+}

--- a/www/src/theme/SearchBar/styles.css
+++ b/www/src/theme/SearchBar/styles.css
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+:root {
+  --docsearch-primary-color: var(--ifm-color-primary);
+  --docsearch-text-color: var(--ifm-font-color-base);
+}
+
+.DocSearch-Button {
+  margin: 0;
+  transition: all var(--ifm-transition-fast)
+    var(--ifm-transition-timing-default);
+}
+
+.DocSearch-Container {
+  z-index: calc(var(--ifm-z-index-fixed) + 1);
+}
+
+.DocSearch-Button-Key {
+  padding: 0;
+}


### PR DESCRIPTION
## Motivation and Resolution

Adds Algolia's **Ask AI** conversational assistant to the documentation site,
on top of the existing DocSearch search. Users can ask natural-language
questions in the search modal and get answers grounded in the starknet.js docs,
with source links.

Ask AI is a DocSearch v4 feature. The assistant is configured in the Algolia
dashboard (Generative AI / Agent Studio, backed by an LLM provider); the
`assistantId` referenced here is a public value, like the existing public search
`apiKey`. No secret is committed — the LLM provider API key lives only in the
Algolia dashboard.

Because the assistant is an **Agent Studio** agent and the native
`@docusaurus/theme-search-algolia` config cannot express the required options,
the `SearchBar` is swizzled (ejected) with a small, documented modification.

### RPC version (if applicable)

Not applicable — documentation-site change only.

## Usage related changes

- The documentation search modal now offers an **Ask AI** conversational mode
  alongside the existing keyword search.
- **Known limitation:** single questions are answered correctly, but follow-up
  (multi-turn) questions currently fail due to an upstream DocSearch v4 +
  Agent Studio bug (the persisted conversation is replayed with a malformed
  message part, rejected with HTTP 422). Full Agent Studio support — including
  multi-turn — is expected in DocSearch v5, at which point the swizzle can be
  removed.

## Development related changes

- Added `@docsearch/react@^4.6.3` as a direct dependency of `www/` so the search
  bar resolves DocSearch v4 (required for Ask AI).
- Added the `askAi` option (public `assistantId`) to the `algolia` block of
  `www/docusaurus.config.ts`.
- Swizzled (ejected) `SearchBar` (`www/src/theme/SearchBar/`). The only changes
  vs. the upstream theme component are:
  - inject `askAi.agentStudio: true` (DocSearch v4 needs it for Agent Studio
    agents; the theme config schema does not allow the flag);
  - drop `searchParameters` from the Ask AI request, since Agent Studio rejects
    the classic `facetFilters` that `contextualSearch` injects (keyword search
    keeps its own contextual `facetFilters`).
- The upstream MIT license header is kept in the swizzled file; the local
  modifications are clearly marked and the file is meant to be re-synced with
  upstream on theme upgrades.

## Checklist:

- [x] Performed a self-review of the code
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] All tests are passing
