### PR TITLE
docs: cleanup in JSDoc

### DIFF
--- a/src/contract/types/index.type.ts
+++ b/src/contract/types/index.type.ts
@@ -134,7 +134,7 @@ export type ParsedEvents = Array<ParsedEvent> & {
 // TODO: This should be in formatResponse type
 /**
  * Advance formatting used to get js types data as result
- * @description https://starknet-io.github.io/starknet.js/docs/guides/define_call_message/#formatresponse
+ * @see https://starknet-io.github.io/starknet.js/docs/guides/define_call_message/#formatresponse
  * @example
  * ```typescript
  * // assign custom or existing method to resulting data

--- a/src/provider/interface.ts
+++ b/src/provider/interface.ts
@@ -250,7 +250,7 @@ export abstract class ProviderInterface {
    * // Equivalent to:
    * const [feeEstimate] = await provider.getEstimateFeeBulk([{ type: ETransactionType.INVOKE, ...invocation, ...details }], options);
    * ```
-   * @alias getEstimateFeeBulk - This method is an alias that calls getEstimateFeeBulk with a single transaction
+   * @remarks This method is an alias that calls getEstimateFeeBulk with a single transaction
    */
   public abstract getInvokeEstimateFee(
     invocation: Invocation,
@@ -280,7 +280,7 @@ export abstract class ProviderInterface {
    * // Equivalent to:
    * const [feeEstimate] = await provider.getEstimateFeeBulk([{ type: ETransactionType.DECLARE, ...transaction, ...details }], options);
    * ```
-   * @alias getEstimateFeeBulk - This method is an alias that calls getEstimateFeeBulk with a single transaction
+   * @remarks This method is an alias that calls getEstimateFeeBulk with a single transaction
    */
   public abstract getDeclareEstimateFee(
     transaction: DeclareContractTransaction,
@@ -311,7 +311,7 @@ export abstract class ProviderInterface {
    * // Equivalent to:
    * const [feeEstimate] = await provider.getEstimateFeeBulk([{ type: ETransactionType.DEPLOY_ACCOUNT, ...transaction, ...details }], options);
    * ```
-   * @alias getEstimateFeeBulk - This method is an alias that calls getEstimateFeeBulk with a single transaction
+   * @remarks This method is an alias that calls getEstimateFeeBulk with a single transaction
    */
   public abstract getDeployAccountEstimateFee(
     transaction: DeployAccountContractTransaction,
@@ -609,7 +609,7 @@ export abstract class ProviderInterface {
    * @param {Signature} signature signature of the message.
    * @param {BigNumberish} accountAddress address of the account that has signed the message.
    * @param {string} [signatureVerificationFunctionName] if account contract with non standard account verification function name.
-   * @param { okResponse: string[]; nokResponse: string[]; error: string[] } [signatureVerificationResponse] if account contract with non standard response of verification function.
+   * @param [signatureVerificationResponse] if account contract with non standard response of verification function.
    * @returns
    * ```typescript
    * const myTypedMessage: TypedMessage = .... ;

--- a/src/utils/calldata/requestParser.ts
+++ b/src/utils/calldata/requestParser.ts
@@ -365,10 +365,6 @@ function parseCalldataValue({
 /**
  * Parse one field of the calldata by using input field from the abi for that method
  *
- * @param argsIterator - Iterator for value of the field
- * @param input  - input(field) information from the abi that will be used to parse the data
- * @param structs - structs from abi
- * @param enums - enums from abi
  * @return {string | string[]} - parsed arguments in format that contract is expecting
  *
  * @example
@@ -420,10 +416,15 @@ export function parseCalldataField({
   enums,
   parser,
 }: {
+  /** Iterator for value of the field */
   argsIterator: Iterator<any>;
+  /** input(field) information from the abi that will be used to parse the data */
   input: AbiEntry;
+  /** structs from abi */
   structs: AbiStructs;
+  /** enums from abi */
   enums: AbiEnums;
+  /** parser used to serialize the value */
   parser: AbiParserInterface;
 }): string | string[] {
   const { name, type } = input;

--- a/src/utils/contractLoader.ts
+++ b/src/utils/contractLoader.ts
@@ -46,7 +46,7 @@ export function isFileSystemAvailable(): boolean {
  * - Can accept a single .sierra.json or .casm file, or multiple files
  * - If compiledClassHash is provided: .casm file is optional
  *
- * @param {string | File | File[]} input - Path (Node.js) or File/File[] (browser)
+ * @param {string | File | File[]} contractPath - Path (Node.js) or File/File[] (browser)
  * @param {string} [compiledClassHash] - Optional compiled class hash. If provided, .casm file becomes optional
  * @return {LoadedContract | Promise<LoadedContract>} - Contract data (sync in Node.js, async in browser)
  * @throws {Error} - If no .sierra.json file is found, or if .casm is missing when compiledClassHash is not provided


### PR DESCRIPTION
## Motivation and Resolution

Building the API documentation with TypeDoc emitted several warnings caused by malformed or unsupported JSDoc tags. This PR cleans up those comments so the docs generation is warning-free. No runtime or public API behavior is affected — these are documentation-only changes.

Warnings fixed:

- `parseCalldataField` (`src/utils/calldata/requestParser.ts`): the function takes a single destructured object, so the per-property `@param` tags (`input`, `structs`, `enums`) were orphaned. Descriptions moved to inline `/** */` comments on the type members.
- `contractLoader` (`src/utils/contractLoader.ts`): the `@param` documented `input`, but the first overload signature names it `contractPath`. Renamed to match.
- `verifyMessageInStarknet` (`src/provider/interface.ts`): a `@param` used single braces for an inline object type (`{ okResponse: ...; ... }`), which the JSDoc parser read as the type and left the parameter name empty (TS hint 8024). Removed the redundant type annotation (TypeDoc takes the type from the TS signature).
- `getInvokeEstimateFee` / `getDeclareEstimateFee` / `getDeployAccountEstimateFee` (`src/provider/interface.ts`): replaced the unsupported `@alias` block tag with `@remarks`.
- `formatResponse` advanced type (`src/contract/types/index.type.ts`): replaced the unsupported `@description` tag with `@see`.

### RPC version (if applicable)

N/A

## Usage related changes

- None. Documentation comments only; no API, type, or runtime behavior change.

## Development related changes

- TypeDoc API docs now build without the `@param ... was not used`, `unknown block tag @alias`, `unknown block tag @description`, and empty-`@param`-name warnings.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] All tests are passing
