### PR TITLE
fix: restore consistency of .toApiRequest() output type

### DIFF
--- a/__tests__/cairo1v2_typed.test.ts
+++ b/__tests__/cairo1v2_typed.test.ts
@@ -964,13 +964,13 @@ describe('Cairo 1', () => {
       expect(callD2).toEqual([hexToDecimalString(encodeShortString(str))]);
       const myCallData = new CallData(CONTRACTS.String.sierra.abi);
       const myCalldata1 = myCallData.compile('proceed_bytes31', [str]);
-      expect(myCalldata1).toEqual([encodeShortString(str)]);
+      expect(myCalldata1).toEqual([hexToDecimalString(encodeShortString(str))]);
       const myCalldata2 = myCallData.compile('proceed_bytes31', { str });
-      expect(myCalldata2).toEqual([encodeShortString(str)]);
+      expect(myCalldata2).toEqual([hexToDecimalString(encodeShortString(str))]);
       const myCall1 = stringContract.populate('proceed_bytes31', [str]);
-      expect(myCall1.calldata).toEqual([encodeShortString(str)]);
+      expect(myCall1.calldata).toEqual([hexToDecimalString(encodeShortString(str))]);
       const myCall2 = stringContract.populate('proceed_bytes31', { str });
-      expect(myCall2.calldata).toEqual([encodeShortString(str)]);
+      expect(myCall2.calldata).toEqual([hexToDecimalString(encodeShortString(str))]);
     });
 
     test('bytes31 too long', async () => {

--- a/__tests__/cairov24onward.test.ts
+++ b/__tests__/cairov24onward.test.ts
@@ -57,14 +57,14 @@ describe('Cairo v2.4 onwards', () => {
 
       const myCallData = new CallData(CONTRACTS.String.sierra.abi);
       const myCalldata1 = myCallData.compile('proceed_bytes31', [str]);
-      expect(myCalldata1).toEqual([encodeShortString(str)]);
+      expect(myCalldata1).toEqual([hexToDecimalString(encodeShortString(str))]);
 
       const myCalldata2 = myCallData.compile('proceed_bytes31', { str });
-      expect(myCalldata2).toEqual([encodeShortString(str)]);
+      expect(myCalldata2).toEqual([hexToDecimalString(encodeShortString(str))]);
       const myCall1 = stringContract.populate('proceed_bytes31', [str]);
-      expect(myCall1.calldata).toEqual([encodeShortString(str)]);
+      expect(myCall1.calldata).toEqual([hexToDecimalString(encodeShortString(str))]);
       const myCall2 = stringContract.populate('proceed_bytes31', { str });
-      expect(myCall2.calldata).toEqual([encodeShortString(str)]);
+      expect(myCall2.calldata).toEqual([hexToDecimalString(encodeShortString(str))]);
     });
 
     test('bytes31 too long', async () => {

--- a/__tests__/utils/cairoDataTypes/CairoByteArray.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoByteArray.test.ts
@@ -12,9 +12,9 @@ describe('CairoByteArray Unit Tests', () => {
 
       // Verify API request format
       const apiRequest = byteArray.toApiRequest();
-      expect(apiRequest[0]).toBe('0x0'); // data length
-      expect(apiRequest[1]).toBe('0x48656c6c6f2c20576f726c6421'); // pending_word as hex
-      expect(apiRequest[2]).toBe('0xd'); // pending_word_len
+      expect(apiRequest[0]).toBe('0'); // data length
+      expect(apiRequest[1]).toBe('5735816763073854918203775149089'); // pending_word as decimal
+      expect(apiRequest[2]).toBe('13'); // pending_word_len
     });
 
     test('should handle exactly 31 bytes string', () => {
@@ -27,7 +27,7 @@ describe('CairoByteArray Unit Tests', () => {
 
       // Verify API request format
       const apiRequest = byteArray.toApiRequest();
-      expect(apiRequest[0]).toBe('0x1'); // data length
+      expect(apiRequest[0]).toBe('1'); // data length
       expect(apiRequest.length).toBe(4); // 1 (length) + 1 (chunk data) + 1 (pending_word) + 1 (pending_word_len)
     });
 
@@ -41,7 +41,7 @@ describe('CairoByteArray Unit Tests', () => {
 
       // Verify API request format
       const apiRequest = byteArray.toApiRequest();
-      expect(apiRequest[0]).toBe('0x2'); // data length
+      expect(apiRequest[0]).toBe('2'); // data length
       expect(apiRequest.length).toBe(5); // 1 (length) + 2 (chunk data) + 1 (pending_word) + 1 (pending_word_len)
     });
 
@@ -54,9 +54,9 @@ describe('CairoByteArray Unit Tests', () => {
 
       // Verify API request format
       const apiRequest = byteArray.toApiRequest();
-      expect(apiRequest[0]).toBe('0x0'); // data length
-      expect(apiRequest[1]).toBe('0x0'); // pending_word as hex
-      expect(apiRequest[2]).toBe('0x0'); // pending_word_len
+      expect(apiRequest[0]).toBe('0'); // data length
+      expect(apiRequest[1]).toBe('0'); // pending_word as decimal
+      expect(apiRequest[2]).toBe('0'); // pending_word_len
     });
   });
 
@@ -293,9 +293,9 @@ describe('CairoByteArray Unit Tests', () => {
       const byteArray = new CairoByteArray('Test');
       const apiRequest = byteArray.toApiRequest();
 
-      expect(apiRequest[0]).toBe('0x0'); // data length (0 chunks)
-      expect(apiRequest[1]).toBe('0x54657374'); // pending_word "Test" as hex
-      expect(apiRequest[2]).toBe('0x4'); // pending_word_len
+      expect(apiRequest[0]).toBe('0'); // data length (0 chunks)
+      expect(apiRequest[1]).toBe('1415934836'); // pending_word "Test" as decimal
+      expect(apiRequest[2]).toBe('4'); // pending_word_len
     });
 
     test('should handle data with multiple chunks', () => {
@@ -303,7 +303,7 @@ describe('CairoByteArray Unit Tests', () => {
       const byteArray = new CairoByteArray(longString);
       const apiRequest = byteArray.toApiRequest();
 
-      expect(apiRequest[0]).toBe('0x1'); // data length (1 chunk)
+      expect(apiRequest[0]).toBe('1'); // data length (1 chunk)
       expect(apiRequest.length).toBe(4); // 1 (length) + 1 (chunk data) + 1 (pending_word) + 1 (pending_word_len)
     });
 
@@ -590,9 +590,9 @@ describe('CairoByteArray Unit Tests', () => {
 
       // Verify API request structure
       expect(apiRequest).toBeInstanceOf(Array);
-      expect(apiRequest[0]).toBe('0x0'); // data length (no complete chunks)
-      expect(typeof apiRequest[1]).toBe('string'); // pending_word as hex string
-      expect(apiRequest[2]).toBe('0x10'); // pending_word_len
+      expect(apiRequest[0]).toBe('0'); // data length (no complete chunks)
+      expect(typeof apiRequest[1]).toBe('string'); // pending_word as decimal string
+      expect(apiRequest[2]).toBe('16'); // pending_word_len
 
       // Deserialize from API response
       const iterator = apiRequest[Symbol.iterator]();
@@ -635,9 +635,9 @@ describe('CairoByteArray Unit Tests', () => {
 
       // Verify API request structure
       expect(apiRequest).toBeInstanceOf(Array);
-      expect(apiRequest[0]).toBe('0x0'); // data length
-      expect(apiRequest[1]).toBe('0x0'); // pending_word
-      expect(apiRequest[2]).toBe('0x0'); // pending_word_len
+      expect(apiRequest[0]).toBe('0'); // data length
+      expect(apiRequest[1]).toBe('0'); // pending_word
+      expect(apiRequest[2]).toBe('0'); // pending_word_len
 
       // Deserialize from API response
       const iterator = apiRequest[Symbol.iterator]();

--- a/__tests__/utils/cairoDataTypes/CairoBytes31.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoBytes31.test.ts
@@ -230,31 +230,31 @@ describe('CairoBytes31 class Unit Tests', () => {
   });
 
   describe('toApiRequest method', () => {
-    test('should return hex string array for empty data', () => {
+    test('should return decimal string array for empty data', () => {
       const bytes31 = new CairoBytes31('');
-      expect(bytes31.toApiRequest()).toEqual(['0x0']);
+      expect(bytes31.toApiRequest()).toEqual(['0']);
     });
 
-    test('should return hex string array for text data', () => {
+    test('should return decimal string array for text data', () => {
       const bytes31 = new CairoBytes31('A'); // ASCII 65
-      expect(bytes31.toApiRequest()).toEqual(['0x41']);
+      expect(bytes31.toApiRequest()).toEqual(['65']);
     });
 
-    test('should return hex string array for multi-byte data', () => {
+    test('should return decimal string array for multi-byte data', () => {
       const bytes31 = new CairoBytes31('AB'); // 0x4142 = 16706
-      expect(bytes31.toApiRequest()).toEqual(['0x4142']);
+      expect(bytes31.toApiRequest()).toEqual(['16706']);
     });
 
-    test('should return hex string array for Buffer input', () => {
+    test('should return decimal string array for Buffer input', () => {
       const buffer = Buffer.from([1, 0]); // 0x0100 = 256
       const bytes31 = new CairoBytes31(buffer);
-      expect(bytes31.toApiRequest()).toEqual(['0x100']);
+      expect(bytes31.toApiRequest()).toEqual(['256']);
     });
 
-    test('should return hex string array for large values', () => {
+    test('should return decimal string array for large values', () => {
       const array = new Uint8Array([222, 173, 190, 239]); // 0xdeadbeef
       const bytes31 = new CairoBytes31(array);
-      expect(bytes31.toApiRequest()).toEqual(['0xdeadbeef']);
+      expect(bytes31.toApiRequest()).toEqual(['3735928559']);
     });
   });
 

--- a/__tests__/utils/cairoDataTypes/CairoFelt252.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoFelt252.test.ts
@@ -298,13 +298,13 @@ describe('CairoFelt252 class Unit Tests', () => {
   });
 
   describe('toApiRequest method', () => {
-    test('should return hex string array', () => {
+    test('should return decimal string array', () => {
       const felt = new CairoFelt252(123n);
-      expect(felt.toApiRequest()).toEqual(['0x7b']);
+      expect(felt.toApiRequest()).toEqual(['123']);
 
       const largeFelt = new CairoFelt252(2n ** 200n);
       expect(largeFelt.toApiRequest()).toEqual([
-        '0x100000000000000000000000000000000000000000000000000',
+        '1606938044258990275541962092341162602522202993782792835301376',
       ]);
     });
   });

--- a/__tests__/utils/cairoDataTypes/CairoInt128.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoInt128.test.ts
@@ -221,26 +221,26 @@ describe('CairoInt128 class Unit Tests', () => {
   });
 
   describe('toApiRequest method', () => {
-    test('should return hex string array for zero', () => {
+    test('should return decimal string array for zero', () => {
       const i128 = new CairoInt128(0);
       const result = i128.toApiRequest();
-      expect(result).toEqual(['0x0']);
+      expect(result).toEqual(['0']);
       expect(result).toHaveProperty('__compiled__', true);
     });
 
-    test('should return hex string array for positive numbers', () => {
+    test('should return decimal string array for positive numbers', () => {
       const i128 = new CairoInt128(10000000000000000000n);
       const result = i128.toApiRequest();
-      expect(result).toEqual(['0x8ac7230489e80000']);
+      expect(result).toEqual(['10000000000000000000']);
       expect(result).toHaveProperty('__compiled__', true);
     });
 
-    test('should return field element hex representation for negative numbers', () => {
+    test('should return field element decimal representation for negative numbers', () => {
       const i128 = new CairoInt128(-10000000000000000000n);
       const result = i128.toApiRequest();
       // Negative value -10000000000000000000 becomes PRIME + (-10000000000000000000) = PRIME - 10000000000000000000
       const fieldElement = PRIME - 10000000000000000000n;
-      const expectedValue = `0x${fieldElement.toString(16)}`;
+      const expectedValue = fieldElement.toString();
       expect(result).toEqual([expectedValue]);
       expect(result).toHaveProperty('__compiled__', true);
     });
@@ -249,8 +249,8 @@ describe('CairoInt128 class Unit Tests', () => {
       const minI128 = new CairoInt128(-(2n ** 127n));
       const maxI128 = new CairoInt128(2n ** 127n - 1n);
       const minFieldElement = PRIME - 2n ** 127n;
-      const expectedMinValue = `0x${minFieldElement.toString(16)}`;
-      const expectedMaxValue = `0x${(2n ** 127n - 1n).toString(16)}`;
+      const expectedMinValue = minFieldElement.toString();
+      const expectedMaxValue = (2n ** 127n - 1n).toString();
       expect(minI128.toApiRequest()).toEqual([expectedMinValue]);
       expect(maxI128.toApiRequest()).toEqual([expectedMaxValue]);
     });

--- a/__tests__/utils/cairoDataTypes/CairoInt16.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoInt16.test.ts
@@ -279,26 +279,26 @@ describe('CairoInt16 class Unit Tests', () => {
   });
 
   describe('toApiRequest method', () => {
-    test('should return hex string array for zero', () => {
+    test('should return decimal string array for zero', () => {
       const i16 = new CairoInt16(0);
       const result = i16.toApiRequest();
-      expect(result).toEqual(['0x0']);
+      expect(result).toEqual(['0']);
       expect(result).toHaveProperty('__compiled__', true);
     });
 
-    test('should return hex string array for positive numbers', () => {
+    test('should return decimal string array for positive numbers', () => {
       const i16 = new CairoInt16(1000);
       const result = i16.toApiRequest();
-      expect(result).toEqual(['0x3e8']);
+      expect(result).toEqual(['1000']);
       expect(result).toHaveProperty('__compiled__', true);
     });
 
-    test('should return field element hex representation for negative numbers', () => {
+    test('should return field element decimal representation for negative numbers', () => {
       const i16 = new CairoInt16(-1000);
       const result = i16.toApiRequest();
       // Negative value -1000 becomes PRIME + (-1000) = PRIME - 1000
       const fieldElement = PRIME - 1000n;
-      const expectedValue = `0x${fieldElement.toString(16)}`;
+      const expectedValue = fieldElement.toString();
       expect(result).toEqual([expectedValue]);
       expect(result).toHaveProperty('__compiled__', true);
     });
@@ -307,9 +307,9 @@ describe('CairoInt16 class Unit Tests', () => {
       const minI16 = new CairoInt16(-32768);
       const maxI16 = new CairoInt16(32767);
       const minFieldElement = PRIME - 32768n;
-      const expectedMinValue = `0x${minFieldElement.toString(16)}`;
+      const expectedMinValue = minFieldElement.toString();
       expect(minI16.toApiRequest()).toEqual([expectedMinValue]);
-      expect(maxI16.toApiRequest()).toEqual(['0x7fff']);
+      expect(maxI16.toApiRequest()).toEqual(['32767']);
     });
   });
 
@@ -389,8 +389,8 @@ describe('CairoInt16 class Unit Tests', () => {
         } else {
           expect(hexVal).toBe(`0x${val.toString(16)}`);
         }
-        // apiRequest should equal hexVal
-        expect(apiRequest[0]).toBe(hexVal);
+        // apiRequest should equal the decimal representation of hexVal
+        expect(apiRequest[0]).toBe(BigInt(hexVal).toString());
       });
     });
 

--- a/__tests__/utils/cairoDataTypes/CairoInt32.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoInt32.test.ts
@@ -290,26 +290,26 @@ describe('CairoInt32 class Unit Tests', () => {
   });
 
   describe('toApiRequest method', () => {
-    test('should return hex string array for zero', () => {
+    test('should return decimal string array for zero', () => {
       const i32 = new CairoInt32(0);
       const result = i32.toApiRequest();
-      expect(result).toEqual(['0x0']);
+      expect(result).toEqual(['0']);
       expect(result).toHaveProperty('__compiled__', true);
     });
 
-    test('should return hex string array for positive numbers', () => {
+    test('should return decimal string array for positive numbers', () => {
       const i32 = new CairoInt32(1000000);
       const result = i32.toApiRequest();
-      expect(result).toEqual(['0xf4240']);
+      expect(result).toEqual(['1000000']);
       expect(result).toHaveProperty('__compiled__', true);
     });
 
-    test('should return field element hex representation for negative numbers', () => {
+    test('should return field element decimal representation for negative numbers', () => {
       const i32 = new CairoInt32(-1000000);
       const result = i32.toApiRequest();
       // Negative value -1000000 becomes PRIME + (-1000000) = PRIME - 1000000
       const fieldElement = PRIME - 1000000n;
-      const expectedValue = `0x${fieldElement.toString(16)}`;
+      const expectedValue = fieldElement.toString();
       expect(result).toEqual([expectedValue]);
       expect(result).toHaveProperty('__compiled__', true);
     });
@@ -318,8 +318,8 @@ describe('CairoInt32 class Unit Tests', () => {
       const minI32 = new CairoInt32(-2147483648);
       const maxI32 = new CairoInt32(2147483647);
       const minFieldElement = PRIME - 2147483648n;
-      const expectedMinValue = `0x${minFieldElement.toString(16)}`;
-      const expectedMaxValue = '0x7fffffff';
+      const expectedMinValue = minFieldElement.toString();
+      const expectedMaxValue = '2147483647';
       expect(minI32.toApiRequest()).toEqual([expectedMinValue]);
       expect(maxI32.toApiRequest()).toEqual([expectedMaxValue]);
     });
@@ -401,8 +401,8 @@ describe('CairoInt32 class Unit Tests', () => {
         } else {
           expect(hexVal).toBe(`0x${val.toString(16)}`);
         }
-        // apiRequest should equal hexVal
-        expect(apiRequest[0]).toBe(hexVal);
+        // apiRequest should equal the decimal representation of hexVal
+        expect(apiRequest[0]).toBe(BigInt(hexVal).toString());
       });
     });
 

--- a/__tests__/utils/cairoDataTypes/CairoInt64.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoInt64.test.ts
@@ -221,26 +221,26 @@ describe('CairoInt64 class Unit Tests', () => {
   });
 
   describe('toApiRequest method', () => {
-    test('should return hex string array for zero', () => {
+    test('should return decimal string array for zero', () => {
       const i64 = new CairoInt64(0);
       const result = i64.toApiRequest();
-      expect(result).toEqual(['0x0']);
+      expect(result).toEqual(['0']);
       expect(result).toHaveProperty('__compiled__', true);
     });
 
-    test('should return hex string array for positive numbers', () => {
+    test('should return decimal string array for positive numbers', () => {
       const i64 = new CairoInt64(1000000000n);
       const result = i64.toApiRequest();
-      expect(result).toEqual(['0x3b9aca00']);
+      expect(result).toEqual(['1000000000']);
       expect(result).toHaveProperty('__compiled__', true);
     });
 
-    test('should return field element hex representation for negative numbers', () => {
+    test('should return field element decimal representation for negative numbers', () => {
       const i64 = new CairoInt64(-1000000000n);
       const result = i64.toApiRequest();
       // Negative value -1000000000 becomes PRIME + (-1000000000) = PRIME - 1000000000
       const fieldElement = PRIME - 1000000000n;
-      const expectedValue = `0x${fieldElement.toString(16)}`;
+      const expectedValue = fieldElement.toString();
       expect(result).toEqual([expectedValue]);
       expect(result).toHaveProperty('__compiled__', true);
     });
@@ -249,8 +249,8 @@ describe('CairoInt64 class Unit Tests', () => {
       const minI64 = new CairoInt64(-(2n ** 63n));
       const maxI64 = new CairoInt64(2n ** 63n - 1n);
       const minFieldElement = PRIME - 2n ** 63n;
-      const expectedMinValue = `0x${minFieldElement.toString(16)}`;
-      const expectedMaxValue = `0x${(2n ** 63n - 1n).toString(16)}`;
+      const expectedMinValue = minFieldElement.toString();
+      const expectedMaxValue = (2n ** 63n - 1n).toString();
       expect(minI64.toApiRequest()).toEqual([expectedMinValue]);
       expect(maxI64.toApiRequest()).toEqual([expectedMaxValue]);
     });

--- a/__tests__/utils/cairoDataTypes/CairoInt8.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoInt8.test.ts
@@ -303,26 +303,26 @@ describe('CairoInt8 class Unit Tests', () => {
   });
 
   describe('toApiRequest method', () => {
-    test('should return hex string array for zero', () => {
+    test('should return decimal string array for zero', () => {
       const i8 = new CairoInt8(0);
       const result = i8.toApiRequest();
-      expect(result).toEqual(['0x0']);
+      expect(result).toEqual(['0']);
       expect(result).toHaveProperty('__compiled__', true);
     });
 
-    test('should return hex string array for positive numbers', () => {
+    test('should return decimal string array for positive numbers', () => {
       const i8 = new CairoInt8(100);
       const result = i8.toApiRequest();
-      expect(result).toEqual(['0x64']);
+      expect(result).toEqual(['100']);
       expect(result).toHaveProperty('__compiled__', true);
     });
 
-    test('should return field element hex representation for negative numbers', () => {
+    test('should return field element decimal representation for negative numbers', () => {
       const i8 = new CairoInt8(-100);
       const result = i8.toApiRequest();
       // Negative value -100 becomes PRIME + (-100) = PRIME - 100
       const fieldElement = PRIME - 100n;
-      const expectedValue = `0x${fieldElement.toString(16)}`;
+      const expectedValue = fieldElement.toString();
       expect(result).toEqual([expectedValue]);
       expect(result).toHaveProperty('__compiled__', true);
     });
@@ -331,9 +331,9 @@ describe('CairoInt8 class Unit Tests', () => {
       const minI8 = new CairoInt8(-128);
       const maxI8 = new CairoInt8(127);
       const minFieldElement = PRIME - 128n;
-      const expectedMinValue = `0x${minFieldElement.toString(16)}`;
+      const expectedMinValue = minFieldElement.toString();
       expect(minI8.toApiRequest()).toEqual([expectedMinValue]);
-      expect(maxI8.toApiRequest()).toEqual(['0x7f']);
+      expect(maxI8.toApiRequest()).toEqual(['127']);
     });
   });
 
@@ -413,8 +413,8 @@ describe('CairoInt8 class Unit Tests', () => {
         } else {
           expect(hexVal).toBe(`0x${val.toString(16)}`);
         }
-        // apiRequest should equal hexVal
-        expect(apiRequest[0]).toBe(hexVal);
+        // apiRequest should equal the decimal representation of hexVal
+        expect(apiRequest[0]).toBe(BigInt(hexVal).toString());
       });
     });
 

--- a/__tests__/utils/cairoDataTypes/CairoUint128.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoUint128.test.ts
@@ -192,32 +192,32 @@ describe('CairoUint128 class Unit Tests', () => {
   });
 
   describe('toApiRequest method', () => {
-    test('should return hex string array for zero', () => {
+    test('should return decimal string array for zero', () => {
       const u128 = new CairoUint128(0);
       const result = u128.toApiRequest();
-      expect(result).toEqual(['0x0']);
+      expect(result).toEqual(['0']);
       expect(result).toHaveProperty('__compiled__', true);
     });
 
-    test('should return hex string array for small numbers', () => {
+    test('should return decimal string array for small numbers', () => {
       const u128 = new CairoUint128(42);
       const result = u128.toApiRequest();
-      expect(result).toEqual(['0x2a']);
+      expect(result).toEqual(['42']);
       expect(result).toHaveProperty('__compiled__', true);
     });
 
-    test('should return hex string array for large numbers', () => {
+    test('should return decimal string array for large numbers', () => {
       const maxU128 = 2n ** 128n - 1n;
       const u128 = new CairoUint128(maxU128);
       const result = u128.toApiRequest();
-      expect(result).toEqual(['0xffffffffffffffffffffffffffffffff']);
+      expect(result).toEqual(['340282366920938463463374607431768211455']);
       expect(result).toHaveProperty('__compiled__', true);
     });
 
     test('should handle bigint input', () => {
       const u128 = new CairoUint128(0x123456789abcdef0123456789abcdefn);
       const result = u128.toApiRequest();
-      expect(result).toEqual(['0x123456789abcdef0123456789abcdef']);
+      expect(result).toEqual(['1512366075204170929049582354406559215']);
       expect(result).toHaveProperty('__compiled__', true);
     });
   });
@@ -323,7 +323,7 @@ describe('CairoUint128 class Unit Tests', () => {
 
         expect(bigintVal).toBe(BigInt(val));
         expect(hexVal).toBe(`0x${val.toString(16)}`);
-        expect(apiRequest[0]).toBe(hexVal);
+        expect(apiRequest[0]).toBe(BigInt(hexVal).toString());
       });
     });
 

--- a/__tests__/utils/cairoDataTypes/CairoUint16.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoUint16.test.ts
@@ -185,31 +185,31 @@ describe('CairoUint16 class Unit Tests', () => {
   });
 
   describe('toApiRequest method', () => {
-    test('should return hex string array for zero', () => {
+    test('should return decimal string array for zero', () => {
       const u16 = new CairoUint16(0);
       const result = u16.toApiRequest();
-      expect(result).toEqual(['0x0']);
+      expect(result).toEqual(['0']);
       expect(result).toHaveProperty('__compiled__', true);
     });
 
-    test('should return hex string array for small numbers', () => {
+    test('should return decimal string array for small numbers', () => {
       const u16 = new CairoUint16(42);
       const result = u16.toApiRequest();
-      expect(result).toEqual(['0x2a']);
+      expect(result).toEqual(['42']);
       expect(result).toHaveProperty('__compiled__', true);
     });
 
-    test('should return hex string array for large numbers', () => {
+    test('should return decimal string array for large numbers', () => {
       const u16 = new CairoUint16(65535);
       const result = u16.toApiRequest();
-      expect(result).toEqual(['0xffff']);
+      expect(result).toEqual(['65535']);
       expect(result).toHaveProperty('__compiled__', true);
     });
 
     test('should handle bigint input', () => {
       const u16 = new CairoUint16(32768n);
       const result = u16.toApiRequest();
-      expect(result).toEqual(['0x8000']);
+      expect(result).toEqual(['32768']);
       expect(result).toHaveProperty('__compiled__', true);
     });
   });
@@ -306,7 +306,7 @@ describe('CairoUint16 class Unit Tests', () => {
 
         expect(bigintVal).toBe(BigInt(val));
         expect(hexVal).toBe(`0x${val.toString(16)}`);
-        expect(apiRequest[0]).toBe(hexVal);
+        expect(apiRequest[0]).toBe(BigInt(hexVal).toString());
       });
     });
 

--- a/__tests__/utils/cairoDataTypes/CairoUint32.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoUint32.test.ts
@@ -193,30 +193,30 @@ describe('CairoUint32 class Unit Tests', () => {
   });
 
   describe('toApiRequest method', () => {
-    test('should return hex string array for zero', () => {
+    test('should return decimal string array for zero', () => {
       const u32 = new CairoUint32(0);
-      expect(u32.toApiRequest()).toEqual(['0x0']);
+      expect(u32.toApiRequest()).toEqual(['0']);
     });
 
-    test('should return hex string array for small numbers', () => {
+    test('should return decimal string array for small numbers', () => {
       const u32 = new CairoUint32(42);
-      expect(u32.toApiRequest()).toEqual(['0x2a']);
+      expect(u32.toApiRequest()).toEqual(['42']);
     });
 
-    test('should return hex string array for large numbers', () => {
+    test('should return decimal string array for large numbers', () => {
       const u32 = new CairoUint32(1000000);
-      expect(u32.toApiRequest()).toEqual(['0xf4240']);
+      expect(u32.toApiRequest()).toEqual(['1000000']);
     });
 
-    test('should return hex string array for maximum u32', () => {
+    test('should return decimal string array for maximum u32', () => {
       const maxU32 = 2n ** 32n - 1n;
       const u32 = new CairoUint32(maxU32);
-      expect(u32.toApiRequest()).toEqual(['0xffffffff']);
+      expect(u32.toApiRequest()).toEqual(['4294967295']);
     });
 
     test('should handle bigint input', () => {
       const u32 = new CairoUint32(12345n);
-      expect(u32.toApiRequest()).toEqual(['0x3039']);
+      expect(u32.toApiRequest()).toEqual(['12345']);
     });
   });
 

--- a/__tests__/utils/cairoDataTypes/CairoUint64.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoUint64.test.ts
@@ -191,32 +191,32 @@ describe('CairoUint64 class Unit Tests', () => {
   });
 
   describe('toApiRequest method', () => {
-    test('should return hex string array for zero', () => {
+    test('should return decimal string array for zero', () => {
       const u64 = new CairoUint64(0);
       const result = u64.toApiRequest();
-      expect(result).toEqual(['0x0']);
+      expect(result).toEqual(['0']);
       expect(result).toHaveProperty('__compiled__', true);
     });
 
-    test('should return hex string array for small numbers', () => {
+    test('should return decimal string array for small numbers', () => {
       const u64 = new CairoUint64(42);
       const result = u64.toApiRequest();
-      expect(result).toEqual(['0x2a']);
+      expect(result).toEqual(['42']);
       expect(result).toHaveProperty('__compiled__', true);
     });
 
-    test('should return hex string array for large numbers', () => {
+    test('should return decimal string array for large numbers', () => {
       const maxU64 = 2n ** 64n - 1n;
       const u64 = new CairoUint64(maxU64);
       const result = u64.toApiRequest();
-      expect(result).toEqual(['0xffffffffffffffff']);
+      expect(result).toEqual(['18446744073709551615']);
       expect(result).toHaveProperty('__compiled__', true);
     });
 
     test('should handle bigint input', () => {
       const u64 = new CairoUint64(0x123456789abcdefn);
       const result = u64.toApiRequest();
-      expect(result).toEqual(['0x123456789abcdef']);
+      expect(result).toEqual(['81985529216486895']);
       expect(result).toHaveProperty('__compiled__', true);
     });
   });
@@ -321,7 +321,7 @@ describe('CairoUint64 class Unit Tests', () => {
 
         expect(bigintVal).toBe(BigInt(val));
         expect(hexVal).toBe(`0x${val.toString(16)}`);
-        expect(apiRequest[0]).toBe(hexVal);
+        expect(apiRequest[0]).toBe(BigInt(hexVal).toString());
       });
     });
 

--- a/__tests__/utils/cairoDataTypes/CairoUint8.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoUint8.test.ts
@@ -211,31 +211,31 @@ describe('CairoUint8 class Unit Tests', () => {
   });
 
   describe('toApiRequest method', () => {
-    test('should return hex string array for zero', () => {
+    test('should return decimal string array for zero', () => {
       const u8 = new CairoUint8(0);
       const result = u8.toApiRequest();
-      expect(result).toEqual(['0x0']);
+      expect(result).toEqual(['0']);
       expect(result).toHaveProperty('__compiled__', true);
     });
 
-    test('should return hex string array for small numbers', () => {
+    test('should return decimal string array for small numbers', () => {
       const u8 = new CairoUint8(42);
       const result = u8.toApiRequest();
-      expect(result).toEqual(['0x2a']);
+      expect(result).toEqual(['42']);
       expect(result).toHaveProperty('__compiled__', true);
     });
 
-    test('should return hex string array for large numbers', () => {
+    test('should return decimal string array for large numbers', () => {
       const u8 = new CairoUint8(255);
       const result = u8.toApiRequest();
-      expect(result).toEqual(['0xff']);
+      expect(result).toEqual(['255']);
       expect(result).toHaveProperty('__compiled__', true);
     });
 
     test('should handle bigint input', () => {
       const u8 = new CairoUint8(128n);
       const result = u8.toApiRequest();
-      expect(result).toEqual(['0x80']);
+      expect(result).toEqual(['128']);
       expect(result).toHaveProperty('__compiled__', true);
     });
   });
@@ -349,7 +349,7 @@ describe('CairoUint8 class Unit Tests', () => {
 
         expect(bigintVal).toBe(BigInt(val));
         expect(hexVal).toBe(`0x${val.toString(16)}`);
-        expect(apiRequest[0]).toBe(hexVal);
+        expect(apiRequest[0]).toBe(BigInt(hexVal).toString());
       });
     });
 

--- a/__tests__/utils/cairoDataTypes/CairoUint96.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoUint96.test.ts
@@ -191,32 +191,32 @@ describe('CairoUint96 class Unit Tests', () => {
   });
 
   describe('toApiRequest method', () => {
-    test('should return hex string array for zero', () => {
+    test('should return decimal string array for zero', () => {
       const u96 = new CairoUint96(0);
       const result = u96.toApiRequest();
-      expect(result).toEqual(['0x0']);
+      expect(result).toEqual(['0']);
       expect(result).toHaveProperty('__compiled__', true);
     });
 
-    test('should return hex string array for small numbers', () => {
+    test('should return decimal string array for small numbers', () => {
       const u96 = new CairoUint96(42);
       const result = u96.toApiRequest();
-      expect(result).toEqual(['0x2a']);
+      expect(result).toEqual(['42']);
       expect(result).toHaveProperty('__compiled__', true);
     });
 
-    test('should return hex string array for large numbers', () => {
+    test('should return decimal string array for large numbers', () => {
       const maxU96 = 2n ** 96n - 1n;
       const u96 = new CairoUint96(maxU96);
       const result = u96.toApiRequest();
-      expect(result).toEqual(['0xffffffffffffffffffffffff']);
+      expect(result).toEqual(['79228162514264337593543950335']);
       expect(result).toHaveProperty('__compiled__', true);
     });
 
     test('should handle bigint input', () => {
       const u96 = new CairoUint96(0x123456789abcdef0123456n);
       const result = u96.toApiRequest();
-      expect(result).toEqual(['0x123456789abcdef0123456']);
+      expect(result).toEqual(['22007822920628982378542166']);
       expect(result).toHaveProperty('__compiled__', true);
     });
   });
@@ -321,7 +321,7 @@ describe('CairoUint96 class Unit Tests', () => {
 
         expect(bigintVal).toBe(BigInt(val));
         expect(hexVal).toBe(`0x${val.toString(16)}`);
-        expect(apiRequest[0]).toBe(hexVal);
+        expect(apiRequest[0]).toBe(BigInt(hexVal).toString());
       });
     });
 

--- a/__tests__/utils/calldata/requestParser.test.ts
+++ b/__tests__/utils/calldata/requestParser.test.ts
@@ -21,7 +21,7 @@ describe('requestParser', () => {
         enums: getAbiEnums(),
         parser: new AbiParser1([getAbiEntry('felt')]),
       });
-      expect(parsedField).toEqual('256');
+      expect(parsedField).toEqual(['256']);
     });
 
     test('should return parsed calldata field for Array type', () => {
@@ -60,7 +60,7 @@ describe('requestParser', () => {
         enums: getAbiEnums(),
         parser: new AbiParser1([getAbiEntry(`${NON_ZERO_PREFIX}core::bool`)]),
       });
-      expect(parsedField).toEqual('1');
+      expect(parsedField).toEqual(['1']);
     });
 
     test('should return parsed calldata field for EthAddress type', () => {
@@ -73,7 +73,7 @@ describe('requestParser', () => {
         enums: getAbiEnums(),
         parser: new AbiParser1([getAbiEntry(`${ETH_ADDRESS}felt`)]),
       });
-      expect(parsedField).toEqual('1952805748');
+      expect(parsedField).toEqual(['1952805748']);
     });
 
     test('should return parsed calldata field for Struct type', () => {

--- a/src/utils/cairoDataTypes/byteArray.ts
+++ b/src/utils/cairoDataTypes/byteArray.ts
@@ -129,7 +129,7 @@ export class CairoByteArray {
     this.assertInitialized();
 
     return addCompiledFlag([
-      addHexPrefix(this.data.length.toString(16)),
+      this.data.length.toString(),
       ...this.data.flatMap((bytes31) => bytes31.toApiRequest()),
       ...this.pending_word.toApiRequest(),
       ...this.pending_word_len.toApiRequest(),

--- a/src/utils/cairoDataTypes/bytes31.ts
+++ b/src/utils/cairoDataTypes/bytes31.ts
@@ -33,7 +33,7 @@ export class CairoBytes31 {
   }
 
   toApiRequest(): string[] {
-    return addCompiledFlag([this.toHexString()]);
+    return addCompiledFlag([BigInt(this.toHexString()).toString()]);
   }
 
   toBigInt() {

--- a/src/utils/cairoDataTypes/felt.ts
+++ b/src/utils/cairoDataTypes/felt.ts
@@ -68,7 +68,7 @@ export class CairoFelt252 {
     /**
      * HexString representation of the felt252
      */
-    return addCompiledFlag([this.toHexString()]);
+    return addCompiledFlag([BigInt(this.toHexString()).toString()]);
   }
 
   static assertRange(val: bigint): void {

--- a/src/utils/cairoDataTypes/int128.ts
+++ b/src/utils/cairoDataTypes/int128.ts
@@ -29,7 +29,7 @@ export class CairoInt128 {
   }
 
   toApiRequest(): string[] {
-    return addCompiledFlag([this.toHexString()]);
+    return addCompiledFlag([BigInt(this.toHexString()).toString()]);
   }
 
   toBigInt() {

--- a/src/utils/cairoDataTypes/int16.ts
+++ b/src/utils/cairoDataTypes/int16.ts
@@ -29,7 +29,7 @@ export class CairoInt16 {
   }
 
   toApiRequest(): string[] {
-    return addCompiledFlag([this.toHexString()]);
+    return addCompiledFlag([BigInt(this.toHexString()).toString()]);
   }
 
   toBigInt() {

--- a/src/utils/cairoDataTypes/int32.ts
+++ b/src/utils/cairoDataTypes/int32.ts
@@ -29,7 +29,7 @@ export class CairoInt32 {
   }
 
   toApiRequest(): string[] {
-    return addCompiledFlag([this.toHexString()]);
+    return addCompiledFlag([BigInt(this.toHexString()).toString()]);
   }
 
   toBigInt() {

--- a/src/utils/cairoDataTypes/int64.ts
+++ b/src/utils/cairoDataTypes/int64.ts
@@ -29,7 +29,7 @@ export class CairoInt64 {
   }
 
   toApiRequest(): string[] {
-    return addCompiledFlag([this.toHexString()]);
+    return addCompiledFlag([BigInt(this.toHexString()).toString()]);
   }
 
   toBigInt() {

--- a/src/utils/cairoDataTypes/int8.ts
+++ b/src/utils/cairoDataTypes/int8.ts
@@ -29,7 +29,7 @@ export class CairoInt8 {
   }
 
   toApiRequest(): string[] {
-    return addCompiledFlag([this.toHexString()]);
+    return addCompiledFlag([BigInt(this.toHexString()).toString()]);
   }
 
   toBigInt() {

--- a/src/utils/cairoDataTypes/uint128.ts
+++ b/src/utils/cairoDataTypes/uint128.ts
@@ -29,7 +29,7 @@ export class CairoUint128 {
   }
 
   toApiRequest(): string[] {
-    return addCompiledFlag([this.toHexString()]);
+    return addCompiledFlag([BigInt(this.toHexString()).toString()]);
   }
 
   toBigInt() {

--- a/src/utils/cairoDataTypes/uint16.ts
+++ b/src/utils/cairoDataTypes/uint16.ts
@@ -29,7 +29,7 @@ export class CairoUint16 {
   }
 
   toApiRequest(): string[] {
-    return addCompiledFlag([this.toHexString()]);
+    return addCompiledFlag([BigInt(this.toHexString()).toString()]);
   }
 
   toBigInt() {

--- a/src/utils/cairoDataTypes/uint32.ts
+++ b/src/utils/cairoDataTypes/uint32.ts
@@ -28,7 +28,7 @@ export class CairoUint32 {
   }
 
   toApiRequest(): string[] {
-    return addCompiledFlag([this.toHexString()]);
+    return addCompiledFlag([BigInt(this.toHexString()).toString()]);
   }
 
   toBigInt() {

--- a/src/utils/cairoDataTypes/uint64.ts
+++ b/src/utils/cairoDataTypes/uint64.ts
@@ -29,7 +29,7 @@ export class CairoUint64 {
   }
 
   toApiRequest(): string[] {
-    return addCompiledFlag([this.toHexString()]);
+    return addCompiledFlag([BigInt(this.toHexString()).toString()]);
   }
 
   toBigInt() {

--- a/src/utils/cairoDataTypes/uint8.ts
+++ b/src/utils/cairoDataTypes/uint8.ts
@@ -29,7 +29,7 @@ export class CairoUint8 {
   }
 
   toApiRequest(): string[] {
-    return addCompiledFlag([this.toHexString()]);
+    return addCompiledFlag([BigInt(this.toHexString()).toString()]);
   }
 
   toBigInt() {

--- a/src/utils/cairoDataTypes/uint96.ts
+++ b/src/utils/cairoDataTypes/uint96.ts
@@ -29,7 +29,7 @@ export class CairoUint96 {
   }
 
   toApiRequest(): string[] {
-    return addCompiledFlag([this.toHexString()]);
+    return addCompiledFlag([BigInt(this.toHexString()).toString()]);
   }
 
   toBigInt() {

--- a/src/utils/calldata/parser/parsingStrategy.ts
+++ b/src/utils/calldata/parser/parsingStrategy.ts
@@ -145,7 +145,7 @@ export const fastParsingStrategy: ParsingStrategy = {
       return new CairoByteArray(val).toApiRequest();
     },
     [CairoFelt252.abiSelector]: (val: unknown) => {
-      return felt(val as BigNumberish);
+      return new CairoFelt252(val).toApiRequest();
     },
     [CairoUint256.abiSelector]: (val: unknown) => {
       return new CairoUint256(val).toApiRequest();


### PR DESCRIPTION
## Motivation and Resolution

Historically, the calldata produced by starknet.js has always been an array of **decimal strings**. At some point the migration of the Cairo data types to dedicated classes (`CairoFelt252`, `CairoIntX`, `CairoBytes31`, …) introduced a divergence: their `toApiRequest()` method started returning **hex** strings (`addCompiledFlag([this.toHexString()])`), while `CairoUint256`/`CairoUint512` (built on top of `CairoFelt`) kept returning decimal.

The result is an inconsistent calldata encoding depending on the type:

| Type | `CallData#compile()` output (before) |
| --- | --- |
| `felt252`, `u8`…`u128`, `u256`, `u512`, `ByteArray` | decimal ✅ |
| `i8`, `i16`, `i32`, `i64`, `i128`, `bytes31` | **hex** ❌ |

In `fastParsingStrategy`, `felt252` and the small uints were also routed through the deprecated standalone `felt()` helper (which returns a scalar `string` instead of the uniform `string[]`), adding a second inconsistency.

Both hex and decimal felts are accepted by the node, so this was never a functional bug at the RPC level — but it broke the long-standing invariant that compiled calldata is uniformly decimal, and made outputs unpredictable from one type to another.

This PR restores full consistency: **all `toApiRequest()` encodings are decimal strings again, as they historically were**, for every Cairo data type.

### RPC version (if applicable)

N/A — encoding only; both representations were already RPC-valid.

## Usage related changes

- `CallData#compile()` (and `toApiRequest()` on every Cairo type) now consistently returns **decimal** string felts. The signed integers (`i8`…`i128`) and `bytes31`, which previously emitted hex, now emit decimal like every other type.
- `felt252` in `fastParsingStrategy` now goes through `new CairoFelt252(val).toApiRequest()` (decimal + felt range validation, and the uniform `string[]` shape) instead of the deprecated `felt()` helper.
- No change to decoded/response values; this only affects the request (calldata) encoding representation.

## Development related changes

- Restored decimal encoding at the source: `toApiRequest()` of `felt252`, `bytes31`, `int8/16/32/64/128`, `uint8/16/32/64/96/128` now build their value with `BigInt(this.toHexString()).toString()` (reusing the existing sign/field-element logic of the integer types), and `ByteArray` emits its data length in decimal.
- Updated the corresponding unit tests (`cairoDataTypes/*`, `requestParser`) to assert the decimal output. `toHexString()` tests are unchanged (that method still returns hex, as intended).

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
