### PR TITLE
Devnet082

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -35,7 +35,7 @@ jobs:
     # TODO - periodically check if conditional services are supported; https://github.com/actions/runner/issues/822
     services:
       devnet:
-        image: ${{ (inputs.use-devnet) && 'shardlabs/starknet-devnet-rs:0.7.0' || '' }}
+        image: ${{ (inputs.use-devnet) && 'shardlabs/starknet-devnet-rs:0.8.2' || '' }}
         ports:
           - 5050:5050
 

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -35,7 +35,7 @@ jobs:
     # TODO - periodically check if conditional services are supported; https://github.com/actions/runner/issues/822
     services:
       devnet:
-        image: ${{ (inputs.use-devnet) && 'shardlabs/starknet-devnet-rs:0.8.2' || '' }}
+        image: ${{ (inputs.use-devnet) && 'shardlabs/starknet-devnet-rs:0.9.0' || '' }}
         ports:
           - 5050:5050
 


### PR DESCRIPTION
## Motivation and Resolution

The CI test suite spins up a `starknet-devnet-rs` service container pinned to `0.7.0`, which is outdated. This PR bumps it to `0.9.0` so integration tests run against a current devnet release.

### RPC version (if applicable)

Devnet `0.9.0` serves RPC spec `0.10.2`, which matches the library's default channel (RPC `0.10.x`). Validated locally against the full test suite.

## Usage related changes

- None. No public API or runtime behavior change.

## Development related changes

- CI: bump the `shardlabs/starknet-devnet-rs` service image from `0.7.0` to `0.9.0` in `.github/workflows/_test.yml`. This affects every workflow that runs tests against devnet (e.g. `[Manual] Test Devnet`).

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] All tests are passing
