### PR TITLE
docs: update versions tables

### DIFF
--- a/www/docs/guides/provider_instance.md
+++ b/www/docs/guides/provider_instance.md
@@ -39,11 +39,11 @@ The Starknet.js version must align with the RPC version supported by the chosen 
 | :---------------------------: | ------------------------------------- |
 |            v0.7.x             | Starknet.js v6.24.1 or v7.6.4         |
 |            v0.8.x             | Starknet.js v7.6.4 or v8.9.2          |
-|            v0.9.x             | Starknet.js v8.9.2, v9.4.2 or v10.3.2 |
-|            v0.10.0            | Starknet.js v9.4.2 or v10.3.2         |
-|            v0.10.1            | Starknet.js v10.3.2                   |
-|            v0.10.2            | Starknet.js v10.3.2                   |
-|            v0.10.3            | Starknet.js v10.3.2                   |
+|            v0.9.x             | Starknet.js v8.9.2, v9.4.2 or v10.4.0 |
+|            v0.10.0            | Starknet.js v9.4.2 or v10.4.0         |
+|            v0.10.1            | Not supported                         |
+|            v0.10.2            | Starknet.js v10.4.0                   |
+|            v0.10.3            | Starknet.js v10.4.0                   |
 
 :::note
 
@@ -88,10 +88,10 @@ import { RpcProvider } from 'starknet';
 
 |                   Node | with public url | with API key |
 | ---------------------: | :-------------: | :----------: |
-| starknet-devnet v0.2.x |      v0_7       |     N/A      |
-| starknet-devnet v0.4.x |      v0_8       |     N/A      |
-| starknet-devnet v0.6.x |      v0_9       |     N/A      |
-| starknet-devnet v0.8.2 |      v0_10      |     N/A      |
+| starknet-devnet v0.2.4 |      v0_7       |     N/A      |
+| starknet-devnet v0.4.3 |      v0_8       |     N/A      |
+| starknet-devnet v0.6.1 |      v0_9       |     N/A      |
+| starknet-devnet v0.9.0 |      v0_10      |     N/A      |
 
 :::note
 


### PR DESCRIPTION
## Motivation and Resolution

The version-compatibility guide (`provider_instance.md`) was outdated and contained an incorrect claim: it listed RPC spec `v0.10.1` as supported by Starknet.js `v10.3.2`.

After verification against the source code, RPC spec `0.10.1` is not part of `SupportedRpcVersion` in **any** `v10.x.x` release (`0.9.0`, `0.10.0`, `0.10.2`, `0.10.3` only), and `isSupportedSpecVersion` matches on the exact patch version. As a result a node advertising `0.10.1` is not actually supported (a plain `new RpcProvider({ nodeUrl })` throws `unsupportedSpecVersion`; only `RpcProvider.create()` degrades it to `0.10.3` with a warning).

This PR updates the tables so the documentation reflects the real behaviour.

### RPC version (if applicable)

No code change. Documentation only:
- RPC `v0.10.1` is now marked as **Not supported**.
- Supported RPC versions for the `0.10` train remain `0.10.0`, `0.10.2`, `0.10.3`.

## Usage related changes

- Updated the RPC-spec ↔ Starknet.js compatibility table: bumped `v10.3.2` references to `v10.4.0`, and flagged RPC `v0.10.1` as **Not supported**.
- Updated the devnet compatibility table to use precise devnet versions (`v0.2.4`, `v0.4.3`, `v0.6.1`, `v0.9.0`) instead of approximate `v0.x.x` labels.

## Development related changes

- None (documentation only).

## Checklist:

- [x] Performed a self-review of the code
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [ ] All tests are passing
