### PR TITLE
ci: bump upload-pages-artifact v3->v5 to drop node20 runtime

### DIFF
--- a/.github/workflows/manual-docs-deploy-pages.yml
+++ b/.github/workflows/manual-docs-deploy-pages.yml
@@ -37,7 +37,7 @@ jobs:
           DOCS_URL: ${{ vars.DOCS_URL || 'https://starknet-io.github.io' }}
           DOCS_BASE_URL: ${{ vars.DOCS_BASE_URL || '/starknet.js/' }}
       - name: Upload
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: www/build
 


### PR DESCRIPTION
## Motivation and Resolution

GitHub Actions is retiring the Node 20 action runtime: actions declaring
`runs.using: node20` are forced onto Node 24 on **2026-06-16** and Node 20 is
**removed on 2026-09-16** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).
Our release and docs-deploy workflows were emitting the warning.

Audited all workflows (transitive deps included) and moved everything to node24:

- **`release.yml`:** dropped the unmaintained `fkirc/skip-duplicate-actions@v5`
  (no node24 release). Its `cancel_others` is replaced by a native
  `concurrency` block scoped to `pull_request` (a release push is never
  cancelled mid-publish).
- **Bumped remaining actions to their node24 majors:** `checkout` v4→v5,
  `setup-node` v4→v5, `github-script` v7→v8, `deploy-pages` v4→v5,
  `upload-pages-artifact` v3→v5 (pins `upload-artifact@v7`).

## Usage related changes

- None. CI/CD only, no impact on SDK users.

## Development related changes

- All workflow actions run on Node 24, ahead of the 2026-06-16 enforcement.
- Validated locally: YAML parse + `actionlint` (0 errors).

## Checklist:

- [x] Performed a self-review of the code
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [x] All tests are passing
