### PR TITLE
feat: add Contract.compile() to build calldata from the abi

### DIFF
--- a/__tests__/contract.test.ts
+++ b/__tests__/contract.test.ts
@@ -1,5 +1,6 @@
 import {
   Account,
+  type Abi,
   Contract,
   ProviderInterface,
   RawArgs,
@@ -52,6 +53,39 @@ describe('contract module', () => {
   });
 
   describe('class Contract {}', () => {
+    describe('reserved method names', () => {
+      // an abi whose entrypoint is named like an internal Contract method
+      const abiWithCompile = [
+        {
+          type: 'function',
+          name: 'compile',
+          inputs: [{ name: 'x', type: 'core::felt252' }],
+          outputs: [],
+          state_mutability: 'external',
+        },
+      ] as Abi;
+
+      test('Contract.compile takes priority over an abi entrypoint named "compile"', () => {
+        const contract = new Contract({ abi: abiWithCompile, address: '0x1' });
+
+        // the snjs method is kept: no own property shadows the prototype method
+        const ownDescriptor = Object.getOwnPropertyDescriptor(contract, 'compile');
+        expect(ownDescriptor).toBeUndefined();
+
+        // and it resolves to the prototype method, not an abi-attached function
+        const isPrototypeMethod = contract.compile === Contract.prototype.compile;
+        expect(isPrototypeMethod).toBe(true);
+
+        // it works as the snjs compile (returns a Calldata synchronously)
+        const calldata = contract.compile('compile', [123]);
+        expect(calldata).toStrictEqual(['123']);
+
+        // the homonym entrypoint stays reachable through the escape hatch
+        const entrypoint = contract.functions.compile;
+        expect(typeof entrypoint).toBe('function');
+      });
+    });
+
     describe('Basic Interaction', () => {
       let erc20Contract: Contract;
 
@@ -930,6 +964,26 @@ describe('Complex interaction', () => {
       ];
       expect(callDataFromObject).toStrictEqual(expectedResult);
       expect(callDataFromArray).toStrictEqual(expectedResult);
+    });
+
+    test('Contract.compile returns the same calldata as myCallData.compile and populate().calldata', () => {
+      const reference = new CallData(echoContract.abi).compile('echo', request);
+
+      // object input, equivalent to the abi-bound myCallData.compile
+      const fromObject = echoContract.compile('echo', request);
+      expect(fromObject).toStrictEqual(reference);
+
+      // array input produces the same result
+      const fromArray = echoContract.compile('echo', Object.values(request));
+      expect(fromArray).toStrictEqual(reference);
+
+      // populate() reuses compile() under the hood
+      const fromPopulate = echoContract.populate('echo', request).calldata;
+      expect(fromPopulate).toStrictEqual(reference);
+
+      // already-compiled calldata is returned as-is (getCompiledCalldata short-circuit)
+      const fromCompiled = echoContract.compile('echo', reference);
+      expect(fromCompiled).toStrictEqual(reference);
     });
 
     test('myCallData.decodeParameters for Cairo 1', async () => {

--- a/src/contract/default.ts
+++ b/src/contract/default.ts
@@ -444,12 +444,15 @@ export class Contract implements ContractInterface {
     throw Error('Contract must be connected to the account contract to estimate');
   }
 
+  public compile(method: string, args: RawArgs = []): Calldata {
+    return getCompiledCalldata(args, () => this.callData.compile(method, args));
+  }
+
   public populate(method: string, args: RawArgs = []): Call {
-    const calldata: Calldata = getCompiledCalldata(args, () => this.callData.compile(method, args));
     return {
       contractAddress: this.address,
       entrypoint: method,
-      calldata,
+      calldata: this.compile(method, args),
     };
   }
 

--- a/src/contract/interface.ts
+++ b/src/contract/interface.ts
@@ -212,6 +212,28 @@ export abstract class ContractInterface {
   public abstract populate(method: string, args?: ArgsOrCalldata): Invocation;
 
   /**
+   * Compile the calldata for a contract method, using the contract abi.
+   *
+   * Unlike {@link populate}, this returns only the compiled `Calldata` array, without wrapping it
+   * in an `Invocation` object (no `contractAddress` nor `entrypoint`). It is the contract-bound
+   * equivalent of `myCallData.compile(method, args)`.
+   *
+   * If `args` is already a compiled `Calldata`, it is returned as-is without recompilation.
+   *
+   * @param method - Name of the contract method, as defined in the abi
+   * @param args - Method arguments as array (in abi order) or object (free order), or an already
+   * compiled calldata
+   * @returns The compiled calldata
+   * @example
+   * ```typescript
+   * // 'amount' is a u256: the abi splits it into 2 felts automatically
+   * const calldata = contract.compile('transfer', { recipient: '0x123', amount: 100n });
+   * // calldata = ['0x123', '100', '0']
+   * ```
+   */
+  public abstract compile(method: string, args?: ArgsOrCalldata): Calldata;
+
+  /**
    * Parse events from a transaction receipt using the contract's ABI
    *
    * @param receipt - Transaction receipt from waitForTransaction

--- a/www/docs/guides/contracts/define_call_message.md
+++ b/www/docs/guides/contracts/define_call_message.md
@@ -456,7 +456,13 @@ const myCall: Call = myContract.populate('get_elements', functionParameters);
 const res = await myContract.get_elements(myCall.calldata);
 ```
 
-It can be used only with methods that know the ABI: `Contract.populate, myCallData.compile`.  
+If you have a `Contract` instance and only need the compiled `Calldata` (not a full `Call`), you can use `Contract.compile`. It is the contract-bound equivalent of `myCallData.compile`, so you don't have to build a `CallData` object yourself:
+
+```typescript
+const myCalldata: Calldata = myContract.compile('setup_elements', functionParameters);
+```
+
+It can be used only with methods that know the ABI: `Contract.populate, Contract.compile, myCallData.compile`.  
 Starknet.js will perform a full check of conformity with the ABI of the contract, reorder the object's properties if necessary, stop if something is wrong or missing, remove not requested properties, and convert everything to Starknet format.  
 Starknet.js will alert you earlier of errors in your parameters (with human comprehensible words), before the call to Starknet. So, no more incomprehensible Starknet messages due to parameters construction.
 
@@ -535,11 +541,12 @@ These types of arguments can't be used at your convenience everywhere. Here is a
 |                                    account.declareAndDeploy |         ✔️          |       ✔️        |                    |                              |                    |                       |           ✔️            |
 |                                            CallData.compile |         ✔️          |       ✔️        |                    |                              |                    |                       |           ✔️            |
 |                                          myCallData.compile |         ✔️          |       ✔️        |         ✔️         |                              |                    |                       |           ✔️            |
+|                                            Contract.compile |         ✔️          |       ✔️        |         ✔️         |                              |                    |                       |           ✔️            |
 |                                           Contract.populate |         ✔️          |       ✔️        |         ✔️         |                              |                    |                       |           ✔️            |
 |                     hash. calculateContract AddressFromHash |         ✔️          |       ✔️        |                    |                              |                    |                       |           ✔️            |
 
 > (\*) = with `parseRequest: false`  
-> (\*\*) = result of `Calldata.compile, myCallData.compile, myContract.populate().calldata`
+> (\*\*) = result of `Calldata.compile, myCallData.compile, myContract.compile, myContract.populate().calldata`
 
 ## Receive data from a Cairo contract
 

--- a/www/docs/guides/contracts/interact.md
+++ b/www/docs/guides/contracts/interact.md
@@ -74,6 +74,8 @@ await myProvider.waitForTransaction(tx2.transaction_hash);
 
 Use `Contract.populate()` to prepare call data for complex parameters or multicalls.
 
+When you only need the compiled `Calldata` (and not a full `Call`), use `Contract.compile()` instead — for example `myContract.compile('transfer', { recipient, amount })` rather than `myContract.populate('transfer', { recipient, amount }).calldata`.
+
 :::
 
 :::info


### PR DESCRIPTION
## Motivation and Resolution

There was no public method on `Contract` to get the compiled `Calldata` of a
method from its abi. Users had two workarounds, both awkward:

- rebuild a `new CallData(myContract.abi).compile(method, args)`, duplicating
  the abi the contract already holds;
- call `myContract.populate(method, args).calldata`, which builds a full `Call`
  object only to throw away `contractAddress` / `entrypoint`, and forces an
  `as Calldata` cast because `populate()` returns an `Invocation` whose
  `calldata` is typed as `RawArgs`.

This PR adds `Contract.compile(method, args): Calldata`, the contract-bound
equivalent of `CallData.compile` / `myCallData.compile`. `populate()` is
refactored to reuse it, so both share a single code path.

### RPC version (if applicable)

N/A

## Usage related changes

- New method `Contract.compile(method, args)` that returns the compiled
  `Calldata` from the contract abi, without wrapping it in a `Call`.
- Naming is consistent with the existing `CallData.compile()` (static, no abi)
  and `myCallData.compile()` (instance, abi-bound).
- It returns a `Calldata` directly, so the previous
  `myContract.populate(method, args).calldata as Calldata` pattern can be
  replaced by `myContract.compile(method, args)` — no `.calldata` access and no
  `as Calldata` cast.
- Already-compiled calldata passed as `args` is returned as-is (same
  short-circuit as `populate`).

## Development related changes

- `Contract.populate()` refactored to delegate calldata building to
  `Contract.compile()` (removes duplicated logic).
- Added an integration test asserting `Contract.compile()` matches
  `myCallData.compile()` and `populate().calldata`, including the
  already-compiled short-circuit.
- Added an offline unit test verifying that the internal `Contract.compile`
  method takes priority over an abi entrypoint literally named `compile`, and
  that such an entrypoint remains reachable via `contract.functions.compile`.
- Updated the guides (`define_call_message.md`, `interact.md`).

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
