### PR TITLE
test: log swallowed error in defaultNodes to diagnose CI flakiness

### DIFF
--- a/__tests__/defaultNodes.test.ts
+++ b/__tests__/defaultNodes.test.ts
@@ -52,6 +52,30 @@ describe('Default RPC Nodes', () => {
                 try {
                   version = await provider.getSpecVersion();
                 } catch (error) {
+                  // TEMPORARY DIAGNOSTIC: surface the swallowed error so CI logs reveal
+                  // whether the failure is a rate-limit (HTTP 429), a timeout, or a 5xx.
+                  // The channel does not expose the HTTP status (it calls response.json()
+                  // directly), so we log the raw error AND re-probe to read response.status.
+                  const e = error as any;
+                  let probe: string;
+                  try {
+                    const r = await fetch(it, {
+                      method: 'POST',
+                      headers: { 'Content-Type': 'application/json' },
+                      body: JSON.stringify({
+                        id: 1,
+                        jsonrpc: '2.0',
+                        method: 'starknet_specVersion',
+                      }),
+                    });
+                    probe = `status=${r.status} ${r.statusText}; body="${(await r.text()).slice(0, 120)}"`;
+                  } catch (probeErr: any) {
+                    probe = `probe failed: ${probeErr?.name}: ${probeErr?.message}`;
+                  }
+                  // eslint-disable-next-line no-console
+                  console.error(
+                    `[defaultNodes] FAIL ${it} | err=${e?.name}: ${e?.message} (code=${e?.code}) | probe=${probe}`
+                  );
                   version = undefined;
                 }
 


### PR DESCRIPTION
## Motivation and Resolution

> ⚠️ **Temporary diagnostic PR — not meant to be merged.** Its only purpose is to
> capture, in CI logs, the real cause of the intermittent failure of
> `defaultNodes.test.ts › All Default RPC Nodes support Spec Versions`.

The test `Default RPC Nodes › All Default RPC Nodes support Spec Versions` fails
intermittently on CI (`expect(finalResult.includes(true)).toBeFalsy()` receives
`true`), while passing 100% locally. The test queries a single public RPC
provider (`api.zan.top`) for every supported spec version and both networks
(mainnet + sepolia), firing all requests concurrently with no retry, timeout or
tolerance — a single failing request fails the whole test.

The root cause cannot currently be identified because the test swallows the
underlying error (`catch { version = undefined }`), so CI logs only show the
final assertion. Moreover, the RPC channel never reads `response.status` (it
calls `response.json()` directly), so an HTTP 429 surfaces as a JSON-parse error
rather than a status code.

This PR temporarily instruments the `catch` block to log:
- the raw swallowed error (`name`, `message`, `code`);
- a direct re-probe of the same endpoint that reads the real `response.status`
  and a snippet of the body.

This will let us distinguish a rate-limit (HTTP 429) from a timeout / connection
reset or a 5xx, and decide on the proper fix afterwards (serialize + backoff,
mock the network call, or add timeout + retry).

### RPC version (if applicable)

N/A

## Usage related changes

- None. No public API change; only test instrumentation.

## Development related changes

- `__tests__/defaultNodes.test.ts`: the failure branch now logs the swallowed
  error plus a direct HTTP-status probe. The instrumentation runs **only on
  failure**, so the happy path stays green and silent.
- Intended to be reverted once the CI logs reveal the cause.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [ ] All tests are passing
