### PR TITLE
docs: add skill in the documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,11 @@ pinned `starknet_specs` dev-dependencies define them. Be version-aware when touc
 - **Do not** commit generated files (`dist/`, coverage). Update `package-lock.json`
   when you change dependencies.
 - Update docs in `www/` and add tests for any behavior change (see CONTRIBUTING.md).
+- [`skills/starknet-js/`](./skills/starknet-js/) is the published agent skill that
+  teaches AI coding agents how to _use_ this library (installable via
+  `npx skills add starknet-io/starknet.js`). If you change the public API surface
+  (signatures, constructor options, calldata handling…), check that the skill files
+  are not made stale, and update them in the same PR if they are.
 
 ## Gotchas
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,6 @@
   <a href="https://starkware.co/">
     <img src="https://img.shields.io/badge/powered_by-StarkWare-navy">
   </a>
-  <a href="https://twitter.com/starknetjs">
-    <img src="https://img.shields.io/badge/follow_us-Twitter-blue">
-  </a>
   <a href="https://www.drips.network/app/projects/github/starknet-io/starknet.js" target="_blank">
     <img src="https://www.drips.network/api/embed/project/https%3A%2F%2Fgithub.com%2Fstarknet-io%2Fstarknet.js/support.png?background=light&style=github&text=project&stat=none" alt="Support starknet.js on drips.network" height="20">
   </a>
@@ -57,6 +54,22 @@ Import `starknet` and use the [API](https://starknet-io.github.io/starknet.js/do
 How to [Guides](https://starknet-io.github.io/starknet.js/docs/guides/intro) :book: & [API](https://starknet-io.github.io/starknet.js/docs/API/) 💻
 
 Play with [Code Examples](https://github.com/PhilippeR26/starknet.js-workshop-typescript) :video_game:
+
+## 🤖 Using AI
+
+AI training data about starknet.js is often outdated. To give your AI coding agent accurate, up-to-date guidance, install the official starknet.js skill ([`skills/starknet-js/`](./skills/starknet-js/)). It works with Claude Code, Codex, Cursor, Gemini CLI, and any other agent supporting the open [Agent Skills](https://agentskills.io/) standard.
+
+```bash
+npx skills add starknet-io/starknet.js
+```
+
+or copy the skill files directly:
+
+```bash
+mkdir -p ~/.claude/skills/starknet-js && curl -s --output-dir ~/.claude/skills/starknet-js --remote-name-all "https://raw.githubusercontent.com/starknet-io/starknet.js/develop/skills/starknet-js/{SKILL.md,calldata.md,interacting.md}"
+```
+
+> This command installs into Claude Code's skills folder — adapt the target directory for other agents.
 
 ## ✏️ Contributing
 

--- a/skills/starknet-js/SKILL.md
+++ b/skills/starknet-js/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: starknet-js
+description: Use when writing or debugging JavaScript/TypeScript that interacts with Starknet through the starknet.js SDK — building Call objects or calldata, encoding/decoding Cairo types (felt252, u256, structs, arrays, spans, ByteArray, Option/Result/custom enums), or working with contracts, accounts, providers, transactions, fees, deployment, or events.
+---
+
+# starknet.js
+
+Official JS/TS SDK for Starknet. This skill targets **starknet.js v10** (API valid for v9, mostly for v8).
+
+**Do not trust training-data memory of starknet.js**: it is typically v5/v6-era and wrong. Constructors now take option objects, only V3 transactions exist (STRK fees, no `maxFee`), and calldata helpers changed. When this skill and memory disagree, the skill wins.
+
+Layer model: `Account` (signs & submits) wraps `RpcProvider` (parses, retries) wraps `RpcChannel` (raw JSON-RPC).
+
+## Reference files
+
+- **[calldata.md](calldata.md)** — REQUIRED reading before encoding or decoding anything: Call/calldata construction, wire format of every Cairo type, enums (Option/Result/custom), ByteArray, string auto-detection traps, response parsing, `decodeParameters`. All examples verified against v10.4.0.
+- **[interacting.md](interacting.md)** — providers, accounts, contracts, multicall, fees/tips, declare/deploy, receipts, events, RPC-version compatibility.
+
+## Non-negotiable v8+ rules
+
+- Only **V3** transactions (INVOKE/DECLARE/DEPLOY_ACCOUNT); fees paid in STRK via `resourceBounds` + `tip`. Never suggest `maxFee` or V1/V2.
+- Constructors take an options object: `new Account({ provider, address, signer })`, `new Contract({ abi, address, providerOrAccount })`, `new RpcProvider({ nodeUrl })`.
+- Never prepend an array length to calldata arrays — the library adds it.
+
+## Quick reference
+
+| Task                      | API                                                                                                                    |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Connect to node           | `new RpcProvider({ nodeUrl })` — or `await RpcProvider.create({ nodeUrl })` to auto-detect RPC version                 |
+| Account                   | `new Account({ provider, address, signer: privateKey })`                                                               |
+| Contract                  | `new Contract({ abi, address, providerOrAccount })`                                                                    |
+| Read                      | `await myContract.my_view_fn(arg1, arg2)` → parsed JS value                                                            |
+| Write                     | `const { transaction_hash } = await myContract.my_fn(args)` then `await provider.waitForTransaction(transaction_hash)` |
+| Build a Call              | `myContract.populate('fn', { ...args })` → `{ contractAddress, entrypoint, calldata }`                                 |
+| Compile calldata (ABI)    | `myContract.compile('fn', args)` or `new CallData(abi).compile('fn', args)`                                            |
+| Compile calldata (no ABI) | `CallData.compile(args)` — several traps, see calldata.md                                                              |
+| Multicall                 | `await account.execute([call1, call2])`                                                                                |
+| Decode raw felts          | `new CallData(abi).decodeParameters('core::…::Type', feltArray)`                                                       |
+| Events                    | `myContract.parseEvents(receipt)`, `provider.getEvents({ ... })`                                                       |
+| Deploy                    | `await Contract.factory({ contract, casm, account, constructorCalldata })`                                             |
+
+## Top mistakes (from outdated model knowledge)
+
+| Mistake                                              | Fix                                                                      |
+| ---------------------------------------------------- | ------------------------------------------------------------------------ |
+| `new Account(provider, address, pk)` positional      | Options object (see above)                                               |
+| `maxFee`, V1/V2 transactions, ETH fees               | V3 only; `resourceBounds` from `estimateInvokeFee`, `tip`                |
+| Manually prepending `array_len`                      | Never — automatic                                                        |
+| `CallData.compile([myU256Bigint])` gives 1 felt      | Use `cairo.uint256(n)` without ABI; a plain bigint is fine only with ABI |
+| `new CairoCustomEnum({ OnlyActive: v })` without ABI | Without ABI, list ALL variants (`undefined` for inactive)                |
+| Expecting `.res`-style result objects                | Cairo 1 returns the value directly (bigint, object, array, enum class)   |

--- a/skills/starknet-js/calldata.md
+++ b/skills/starknet-js/calldata.md
@@ -1,0 +1,316 @@
+# Encoding & decoding Cairo values (Call / calldata)
+
+Every concrete output in this file was executed and verified against starknet.js v10.4.0.
+
+## Wire format
+
+Starknet functions consume and return a flat list of field elements ("felts"). In starknet.js:
+
+- `Calldata` = `string[]` of **decimal** number strings (`['291', '50', '0']`).
+- `BigNumberish` = `number` (integer ≤ 2^53) | `string` (decimal `"123"` or hex `"0xabc"`) | `bigint`.
+- A felt252 is an integer in `[0, P)` with `P = 2^251 + 17·2^192 + 1`.
+
+Serialization layouts:
+
+| Cairo type                                                                                                                    | Felts on the wire                                                            |
+| ----------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `felt252`, `u8…u128`, `usize`, `bool`, `bytes31`, `ContractAddress`, `ClassHash`, `EthAddress`, u96 (`BoundedInt<0, 2^96-1>`) | 1 felt                                                                       |
+| `i8…i128`, negative value `n`                                                                                                 | 1 felt = `P + n` (e.g. `-5` → `P - 5`)                                       |
+| `u256`                                                                                                                        | 2 felts: `[low 128b, high 128b]`                                             |
+| `u512`                                                                                                                        | 4 felts: `[limb0 (lowest), limb1, limb2, limb3]`                             |
+| `Array<T>`, `Span<T>`                                                                                                         | `[len, ...items]`                                                            |
+| `[T; N]` (fixed array)                                                                                                        | N serialized items, **no length**                                            |
+| tuple `(A, B)`, struct                                                                                                        | concatenation of members, no prefix                                          |
+| `ByteArray`                                                                                                                   | `[data_len, ...data words (31-char chunks), pending_word, pending_word_len]` |
+| `Option<T>`                                                                                                                   | Some: `[0, ...T]` — None: `[1]`                                              |
+| `Result<T, E>`                                                                                                                | Ok: `[0, ...T]` — Err: `[1, ...E]`                                           |
+| custom enum                                                                                                                   | `[variant_index, ...payload]`; unit variant `()`: `[variant_index]` only     |
+| `NonZero<T>`                                                                                                                  | same as `T`                                                                  |
+| `Secp256k1Point`                                                                                                              | 4 felts: `[x.low, x.high, y.low, y.high]`                                    |
+
+## Three ways to build calldata
+
+| You have            | Use                                                                                   | Safety                                                     |
+| ------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `Contract` instance | `contract.populate('fn', args)` → `Call`; `contract.compile('fn', args)` → `Calldata` | Full ABI validation, object properties may be in any order |
+| ABI only            | `const cd = new CallData(abi); cd.compile('fn', args)`                                | Same                                                       |
+| No ABI              | `CallData.compile(args)` (static)                                                     | Type inferred from JS values — see traps below             |
+
+Prefer the ABI-aware paths. They validate, reorder object properties to match the ABI, strip stray `*_len` entries, and produce human-readable errors before anything is sent to the network.
+
+```ts
+import { Contract, CallData, cairo } from 'starknet';
+
+// ABI-aware (recommended)
+const call = myContract.populate('transfer', { recipient: addr, amount: 1000n });
+// call = { contractAddress, entrypoint: 'transfer', calldata: ['291', '1000', '0'] }
+await account.execute(call);
+
+// no ABI — u256 must be built explicitly
+const raw = CallData.compile({ recipient: addr, amount: cairo.uint256(1000n) });
+```
+
+## Accepted JS inputs per Cairo type (ABI-aware paths)
+
+| Cairo type                                                    | JS input                                                                                      |
+| ------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `felt252`, `u8…u128`, `usize`, `ContractAddress`, `ClassHash` | `BigNumberish`                                                                                |
+| `felt252`, `bytes31` (as text)                                | `string` ≤ 31 chars that is NOT hex/decimal-looking                                           |
+| `i8…i128`                                                     | `BigNumberish`, negatives allowed                                                             |
+| `bool`                                                        | `boolean` or `0`/`1`                                                                          |
+| `u256`                                                        | `BigNumberish` or `{ low, high }` or `cairo.uint256(x)`                                       |
+| `u512`                                                        | `BigNumberish` or `cairo.uint512(x)` (4 limbs)                                                |
+| `Array<T>` / `Span<T>`                                        | JS array — **never** prepend the length                                                       |
+| `[T; N]`                                                      | JS array of exactly N items (with ABI)                                                        |
+| tuple                                                         | `cairo.tuple(a, b)` or `{ 0: a, 1: b }`; Cairo 0 named tuple also accepts `{ min, max }`      |
+| struct                                                        | plain object `{ member: value, ... }`                                                         |
+| `ByteArray` (long string)                                     | plain JS `string`, any length                                                                 |
+| `Option<T>`                                                   | `new CairoOption<T>(CairoOptionVariant.Some, content)` / `(CairoOptionVariant.None)`          |
+| `Result<T, E>`                                                | `new CairoResult<T, E>(CairoResultVariant.Ok, content)` / `(CairoResultVariant.Err, content)` |
+| custom enum                                                   | `new CairoCustomEnum({ ActiveVariant: content })`                                             |
+| `EthAddress`                                                  | `BigNumberish` (160 bits)                                                                     |
+| `Secp256k1Point`                                              | 512-bit `BigNumberish` (uncompressed pubkey, no parity byte)                                  |
+| `NonZero<T>`                                                  | same as `T`, non-zero                                                                         |
+
+Imports: `import { CallData, cairo, CairoOption, CairoOptionVariant, CairoResult, CairoResultVariant, CairoCustomEnum, CairoFixedArray, byteArray, shortString, num, uint256 } from 'starknet';`
+
+## String auto-detection (major trap)
+
+A JS string argument is interpreted by content:
+
+- hex string (`'0x7b'`) → the number 123
+- whole-decimal string (`'123'`) → the number 123
+- other text ≤ 31 ASCII chars → one felt, short-string encoded (`'Token'` → `0x546f6b656e` = `'362646562158'`)
+- other text > 31 chars → `ByteArray` struct (or split into 31-char chunks if the ABI expects `Array<felt252>`)
+
+Consequences, all verified:
+
+- User-supplied text that happens to look numeric (`'123'`) is sent as a number, not as text. To force text encoding: `shortString.encodeShortString('123')`.
+- A long string passed for `Array<felt252>` is split into 31-char chunks, then **each chunk is re-interpreted**: a numeric-looking chunk (e.g. final chunk `'67'`) is encoded as the number 67, not as text. For a lossless long string over `Array<felt252>`, encode manually:
+  ```ts
+  const feltArray = shortString.splitLongString(longText).map(shortString.encodeShortString);
+  ```
+- `ByteArray` encoding (`byteArray.byteArrayFromString`) does NOT have this trap — chunks are always text-encoded.
+
+## Worked examples (exact outputs)
+
+Cairo signatures on the left, `cd = new CallData(abi)`:
+
+```ts
+// fn f1(recipient: ContractAddress, amount: u256)
+cd.compile('f1', { recipient: '0x123', amount: 50n }); // ['291', '50', '0']
+cd.compile('f1', { amount: 50n, recipient: '0x123' }); // same — object order fixed via ABI
+cd.compile('f1', ['0x123', cairo.uint256(2n ** 128n)]); // ['291', '0', '1']
+
+// fn f2(list: Array<u8>)
+cd.compile('f2', [[1, 2, 3]]); // ['3', '1', '2', '3'] (length added)
+
+// fn f3(name: felt252)
+cd.compile('f3', ['Token']); // ['362646562158'] (0x546f6b656e)
+
+// fn f4(msg: ByteArray)
+cd.compile('f4', ['ABCDEFGHI']); // ['0', '1203813099885386221641', '9']
+//   9 chars < 31: data=[], pending_word=0x414243444546474849, pending_word_len=9
+cd.compile('f4', ['ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567']); // ['1', <31-char word>, '13879', '2']
+//   33 chars: data_len=1, one full word, pending_word='67' as text (0x3637), len=2
+
+// fn f6(fix: [u32; 3])
+cd.compile('f6', [[10, 20, 30]]); // ['10', '20', '30'] (no length)
+
+// fn f7(t: (u16, Order), s: Order)   with struct Order { p1: felt252, p2: u16 }
+cd.compile('f7', [cairo.tuple(7, { p1: 8, p2: 9 }), { p1: 10, p2: 11 }]);
+//                                                              // ['7', '8', '9', '10', '11']
+
+// fn f8(i: i8)
+cd.compile('f8', [-5]); // [(P - 5n).toString()]
+
+// fn f9(b: bool, addr: EthAddress)
+cd.compile('f9', [true, '0xff00ff']); // ['1', '16711935']
+```
+
+## Cairo enums
+
+`CairoOption`, `CairoResult`, `CairoCustomEnum` are used both to **send** and as **received** values.
+
+```ts
+// enum MyEnum { Response: Order, Warning: felt252, Error: (u16, u16), Critical: Array<u32>, Empty: () }
+// fn f5(opt: Option<u16>, res: Result<u64, u8>, en: MyEnum)
+cd.compile('f5', [
+  new CairoOption<number>(CairoOptionVariant.Some, 8), // → ['0', '8']
+  new CairoResult<number, number>(CairoResultVariant.Ok, 3), // → ['0', '3']
+  new CairoCustomEnum({ Warning: 'attention' }), // → ['1', '1797725618680598458222']
+]); // all concatenated
+
+cd.compile('f5', [
+  new CairoOption<number>(CairoOptionVariant.None), // → ['1']
+  new CairoResult<number, number>(CairoResultVariant.Err, 9), // → ['1', '9']
+  new CairoCustomEnum({ Empty: {} }), // unit variant (index 4) → ['4']
+]);
+```
+
+Received enums are class instances:
+
+```ts
+const opt = await myContract.maybe_order(50); // CairoOption<Order>
+opt.isSome();
+opt.isNone();
+opt.unwrap(); // unwrap(): content | undefined
+
+const res = await myContract.checked_op(1); // CairoResult<T, E>
+res.isOk();
+res.isErr();
+res.unwrap(); // unwrap() returns Ok OR Err content
+
+const en = await myContract.state(); // CairoCustomEnum
+en.activeVariant(); // 'Warning'
+en.unwrap(); // active variant content
+en.variant.Response; // direct access (undefined if inactive)
+```
+
+## Static `CallData.compile` (no ABI) — traps
+
+Type is inferred from the JS value only. Verified behaviors:
+
+```ts
+CallData.compile([50n]); // ['50'] — ONE felt; wrong for a u256 param!
+CallData.compile([cairo.uint256(50n)]); // ['50', '0'] — correct u256
+CallData.compile([cairo.uint512(50n)]); // ['50', '0', '0', '0']
+CallData.compile([[1, 2, 3]]); // ['3', '1', '2', '3'] — length auto-added
+CallData.compile([CairoFixedArray.compile([10, 20, 30])]); // ['10','20','30'] — fixed array, no length
+CallData.compile(['Token']); // ['362646562158'] — short text → 1 felt
+CallData.compile(['<33-char text>']); // ByteArray layout, automatic
+CallData.compile([{ p1: 8, p2: 9 }]); // ['8', '9'] — object flattened in property order
+CallData.compile([true, false]); // ['1', '0']
+CallData.compile([new CairoOption(CairoOptionVariant.Some, 8)]); // ['0', '8']
+```
+
+- **Property order matters** (no ABI to reorder objects). `{ low, high }` for u256, in that order.
+- **Custom enums: list ALL variants** (`undefined` for inactive ones) so the variant index can be derived from position, and **wrap the enum in an array** — `CallData.compile(myEnum)` passed directly (not `[myEnum]`) throws `undefined can't be computed by felt()` in v10:
+  ```ts
+  const en = new CairoCustomEnum({
+    Response: undefined,
+    Warning: undefined,
+    Error: cairo.tuple(100, 110),
+    Critical: undefined,
+    Empty: undefined,
+  });
+  CallData.compile([en]); // ['2', '100', '110']
+  ```
+- Fixed arrays: a plain JS array would get a length prefix — use `CairoFixedArray.compile([...])` (returns `{ 0: v, 1: v, ... }`).
+- `CallData.toHex(args)` — same as compile but hex output. `CallData.toCalldata` = alias of compile.
+
+## Decoding responses
+
+`myContract.call(...)` / meta-class reads return parsed values (Cairo 1):
+
+| Cairo output type                                                                                      | JS result                                                  |
+| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
+| `u8…u128`, `usize`, `felt252`, `ContractAddress`, `ClassHash`, `EthAddress`, `i8…i128`, `u256`, `u512` | `bigint`                                                   |
+| `bool`                                                                                                 | `boolean`                                                  |
+| `bytes31`                                                                                              | `string` (text-decoded)                                    |
+| `ByteArray`                                                                                            | `string` (text-decoded)                                    |
+| `Array<T>` / `Span<T>` / `[T; N]`                                                                      | JS array of parsed T                                       |
+| struct                                                                                                 | object `{ member: parsed }`                                |
+| tuple                                                                                                  | object `{ '0': parsed, '1': parsed }`                      |
+| `Option` / `Result` / custom enum                                                                      | `CairoOption` / `CairoResult` / `CairoCustomEnum` instance |
+| single output                                                                                          | returned directly (not wrapped)                            |
+
+- `felt252` returns a `bigint` even when it holds text. Decode text manually: `shortString.decodeShortString(num.toHex(value))`.
+- A Cairo 1 function returning several values returns a tuple → object with `'0'`, `'1'`… keys.
+- Cairo 0 contracts return objects keyed by output names (e.g. `res.balance`).
+
+### Decode arbitrary felts: `decodeParameters`
+
+```ts
+const cd = new CallData(abi);
+cd.decodeParameters('mymod::MyStruct', ['0x123456', '0x1']); // { a: 1193046n, b: true }
+cd.decodeParameters('core::integer::u256', ['0x64', '0x0']); // 100n
+cd.decodeParameters(['core::felt252', 'core::bool'], ['0x1', '0x0']); // [1n, false]
+```
+
+### Parse options (per-call)
+
+```ts
+await myContract.call('get_bal', rawFelts, { parseRequest: false }); // send raw felts untouched
+await myContract.call('get_bals', [100n], { parseResponse: false }); // raw string[] back
+// formatResponse: post-process parsed bigints ('string' = decode short/long string,
+// 'number' = Number(), or a custom (value) => any function; nest for structs/arrays)
+await myContract.get_text({ formatResponse: { name: 'string', description: 'string' } });
+// same options on a Contract via .withOptions({...}) for the next call only
+```
+
+## Which argument shapes does each API accept?
+
+| API                                                                                                   | Accepted args                                                                |
+| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| meta-class `myContract.fn(a, b, c)`                                                                   | spread list of parameters (or `...myArray`), or a single compiled `Calldata` |
+| `contract.call/invoke('fn', args)`                                                                    | array of parameters, or compiled `Calldata`                                  |
+| `contract.populate` / `contract.compile` / `myCallData.compile`                                       | array of parameters, or object (any property order)                          |
+| `CallData.compile` (static) / `account.execute({...calldata})` / `deployContract.constructorCalldata` | array of parameters, or object in ABI property order                         |
+
+A compiled `Calldata` (output of any `compile`/`populate().calldata`) is accepted everywhere calldata is expected.
+
+## Hand-crafting a minimal ABI
+
+To use `new CallData(abi)` / `decodeParameters` without a compiled contract, write ABI entries with fully-qualified type paths:
+
+```ts
+const abi = [
+  {
+    type: 'struct',
+    name: 'mymod::Order',
+    members: [
+      { name: 'p1', type: 'core::felt252' },
+      { name: 'p2', type: 'core::integer::u16' },
+    ],
+  },
+  {
+    type: 'enum',
+    name: 'core::option::Option::<core::integer::u16>',
+    variants: [
+      { name: 'Some', type: 'core::integer::u16' },
+      { name: 'None', type: '()' },
+    ],
+  },
+  {
+    type: 'function',
+    name: 'f',
+    state_mutability: 'external',
+    inputs: [{ name: 'opt', type: 'core::option::Option::<core::integer::u16>' }],
+    outputs: [],
+  },
+];
+```
+
+Every `Option`/`Result`/custom enum type used must appear as its own `enum` entry (variants `Some`/`None`, `Ok`/`Err`). Common type strings: `core::felt252`, `core::integer::u8…u256`, `core::bool`, `core::byte_array::ByteArray`, `core::bytes_31::bytes31`, `core::array::Array::<T>`, `core::array::Span::<T>`, `[core::integer::u32; 3]`, `(core::integer::u16, mymod::Order)`, `core::starknet::contract_address::ContractAddress`, `core::starknet::eth_address::EthAddress`, `core::zeroable::NonZero::<T>`.
+
+## Manual helpers
+
+```ts
+shortString.encodeShortString('uri/pict/t38.jpg'); // '0x7572692f706963742f7433382e6a7067'
+shortString.decodeShortString('0x7572692f...'); // 'uri/pict/t38.jpg'
+shortString.splitLongString(text); // 31-char chunks
+byteArray.byteArrayFromString('ABCDEFGHI'); // { data: [], pending_word: '0x4142…49', pending_word_len: 9 }
+byteArray.stringFromByteArray(ba); // back to JS string
+cairo.uint256(2n ** 128n + 5n); // { low: '5', high: '1' }
+cairo.tuple(10, 20); // { 0: 10, 1: 20 }
+cairo.felt('ABC'); // '4276803' (short-string encoded)
+cairo.isCairo1Abi(abi);
+myContract.isCairo1(); // Cairo version detection
+num.toHex(291); // '0x123'
+uint256.uint256ToBN({ low, high }); // bigint
+```
+
+## Common mistakes
+
+| Mistake                                                  | Reality                                                                                            |
+| -------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Prepending `array_len` before an array                   | The library adds length prefixes; a stray `_len` property is ignored/rejected                      |
+| Plain bigint for u256 in static `CallData.compile`       | Encodes 1 felt; use `cairo.uint256()` or `{ low, high }`                                           |
+| `new CairoCustomEnum({ Active: v })` in static compile   | Variant index unknowable without ABI — list all variants; with ABI the single-variant form is fine |
+| `CallData.compile(myEnum)` un-wrapped                    | Throws in v10 — wrap: `CallData.compile([myEnum])`                                                 |
+| Passing `'123'` expecting text                           | Numeric-looking strings become numbers; use `encodeShortString`                                    |
+| JS array for `[T; N]` in static compile                  | Gets a length prefix; use `CairoFixedArray.compile([...])`                                         |
+| Expecting `string` from a `felt252` return               | You get `bigint`; decode with `shortString.decodeShortString(num.toHex(v))`                        |
+| Reading `res.Some` on a returned Option                  | Use `res.isSome()` / `res.unwrap()`                                                                |
+| Object args to static `CallData.compile` in random order | Static compile can't reorder — properties must follow ABI order                                    |

--- a/skills/starknet-js/interacting.md
+++ b/skills/starknet-js/interacting.md
@@ -1,0 +1,157 @@
+# Providers, accounts, contracts, transactions (starknet.js v10)
+
+## RpcProvider
+
+```ts
+import { RpcProvider, constants, BlockTag } from 'starknet';
+
+const provider = new RpcProvider({ nodeUrl: 'https://…/rpc/v0_10' }); // default channel: RPC 0.10
+const provider09 = new RpcProvider({ nodeUrl: '…/rpc/v0_9', specVersion: '0.9.0' });
+const auto = await RpcProvider.create({ nodeUrl }); // queries the node, picks the right channel
+const sepolia = new RpcProvider(); // random public Sepolia node
+const mainnet = new RpcProvider({ nodeUrl: constants.NetworkName.SN_MAIN });
+```
+
+- The constructor does NOT read the RPC version from the URL: pass `specVersion` or use `RpcProvider.create()`.
+- v10 talks RPC spec **0.9 and 0.10** (v8: 0.8/0.9; v7: 0.7/0.8). Devnet: `http://127.0.0.1:5050/rpc`.
+- Useful: `getSpecVersion()`, `getBlock('latest')`, `getClassAt(addr)` (→ `{ abi }`), `getNonceForAddress`, `getEvents`, `waitForTransaction`.
+- Batching: `new RpcProvider({ batch: 0 })` merges concurrent requests into one HTTP call.
+- Errors: `catch (e) { if (e instanceof RpcError && e.isType('CONTRACT_NOT_FOUND')) … }`.
+
+## Account
+
+```ts
+import { Account, EthSigner } from 'starknet';
+
+const account = new Account({
+  provider,
+  address: accountAddress,
+  signer: privateKey, // string | Uint8Array | SignerInterface (e.g. new EthSigner(pk))
+  // optional: cairoVersion: '1', paymaster, deployer (defaultDeployer | legacyDeployer),
+  // defaultTipType: 'recommendedTip' | 'minTip' | 'maxTip' | 'averageTip' | 'medianTip' | 'modeTip' | 'p90Tip' | 'p95Tip'
+});
+```
+
+Only V3 transactions (STRK fees). Fee control per call via details object: `{ tip, resourceBounds, nonce, blockIdentifier }`.
+
+```ts
+// fees: estimate then reuse
+const { resourceBounds } = await account.estimateInvokeFee(calls);
+const tipStats = await provider.getEstimateTip();
+const res = await account.execute(calls, { resourceBounds, tip: tipStats.recommendedTip });
+
+// multicall — atomic, single transaction, ordered
+const res2 = await account.execute([call1, call2, call3]);
+await provider.waitForTransaction(res2.transaction_hash);
+```
+
+Other: `account.getNonce()`, `account.signMessage(typedData)`, `account.getSignedTransaction(calls)` (build without sending), `account.executeFromOutside` (SNIP-9), `account.executePaymasterTransaction` (SNIP-29 gas in any token).
+
+## Contract
+
+```ts
+import { Contract, json } from 'starknet';
+// parse compiled artifacts with json.parse (handles bigints), NOT JSON.parse
+const sierra = json.parse(fs.readFileSync('./x.contract_class.json').toString('ascii'));
+
+const myContract = new Contract({
+  abi: sierra.abi,
+  address: contractAddress,
+  providerOrAccount: account, // Provider = read-only; Account = read-write
+});
+```
+
+- Read (view fn): `const v = await myContract.get_balance(addr);` — parsed JS value (see calldata.md).
+- Write: `const { transaction_hash } = await myContract.transfer(to, amount);` then `waitForTransaction`.
+- `myContract.withOptions({ blockIdentifier, tip, resourceBounds, parseRequest, parseResponse, formatResponse, waitForTransaction }).fn(args)` — applies to the **next call only**. With `waitForTransaction: true`, `invoke` waits and returns the successful receipt (throws on failure).
+- `myContract.estimateFee.transfer(to, amount)` → `{ resourceBounds, … }`.
+- `myContract.populate('fn', args)` → `Call` for multicall; `myContract.compile('fn', args)` → `Calldata` (v10).
+- Dynamic name: `await myContract[fnName](...args)`. Check deployment: `await myContract.isDeployed()`.
+- Typed ABI (autocompletion): `const typed = myContract.typedv2(myAbiAsConst);` (abi-wan-kanabi).
+
+## Receipts
+
+```ts
+const txR = await provider.waitForTransaction(transaction_hash);
+txR.isSuccess();
+txR.isReverted();
+txR.isError();
+txR.match({
+  success: (r) => console.log('ok', r),
+  reverted: (r) => console.log('reverted', r.revert_reason),
+  _: () => console.log('other'),
+});
+if (txR.isSuccess()) {
+  const receipt = txR.value;
+} // raw receipt (events, actual_fee, …)
+```
+
+## Declare & deploy
+
+```ts
+// one-shot: declare (if needed) + deploy + ready-to-use instance
+const myContract = await Contract.factory({
+  contract: sierra,
+  casm, // or: classHash (+ optional abi) for deploy-only
+  account,
+  constructorCalldata: { name: 'MyToken', symbol: 'MTK' }, // ABI-checked
+  // salt, unique: false → predictable address
+});
+
+// fine-grained account methods
+const d = await account.declareIfNot({ contract: sierra, casm }); // '' tx hash if known
+const dep = await account.deployContract({ classHash, constructorCalldata, abi }); // via UDC
+const both = await account.declareAndDeploy({ contract: sierra, casm, constructorCalldata });
+const newAcc = await account.deployAccount({ classHash, constructorCalldata, addressSalt });
+```
+
+Address precomputation: `hash.calculateContractAddressFromHash(salt, classHash, constructorCalldata, deployerOrZero)`.
+
+## Events
+
+```ts
+// from a receipt (contract must have emitted them)
+const events = myContract.parseEvents(txR); // [{ EventName: { field: value } }]
+
+// searching blocks
+const keyFilter = [[num.toHex(hash.starknetKeccak('EventPanic'))], ['0x8']];
+// semantics: [[A,B],[C]] = (key0 = A or B) AND (key1 = C); [[]] = no filter on that key
+const chunk = await provider.getEvents({
+  address,
+  from_block: { block_number: n0 },
+  to_block: { block_number: n1 },
+  keys: keyFilter,
+  chunk_size: 100,
+  // loop with continuation_token: chunk.continuation_token until undefined
+});
+```
+
+Caution: events defined in a Cairo component without `#[flat]` carry extra leading key hashes — shift the filter accordingly.
+
+## Fast consecutive transactions (gaming)
+
+FastExecute plugin (installed by default) + `blockIdentifier: BlockTag.PRE_CONFIRMED` on the provider (RPC ≥ 0.9): `account.fastExecute(call, { tip }, { retries: 30, retryInterval: 500 })` → `{ isReady, … }` in 2–3 s instead of >10 s. Not for deployments; heavy on the node.
+
+## Utilities cheat-sheet
+
+```ts
+hash.getSelectorFromName('transfer'); // entrypoint selector
+hash.starknetKeccak('EventName'); // event key (bigint)
+stark.randomAddress(); // random salt/private key material
+encode.addHexPrefix / removeHexPrefix;
+num.toHex(bn);
+num.toBigInt(x);
+num.hexToDecimalString(h);
+shortString / byteArray / cairo / uint256; // see calldata.md
+```
+
+## Version compatibility (node RPC spec ↔ starknet.js)
+
+| RPC spec | starknet.js       |
+| -------- | ----------------- |
+| 0.7.x    | v6 / v7           |
+| 0.8.x    | v7 / v8           |
+| 0.9.x    | v8 / v9 / v10     |
+| 0.10.x   | v9 (0.10.0) / v10 |
+
+Starknet ≥ 0.14 (v8+): V3-only transactions, pre-confirmed block state, mandatory tips.

--- a/www/README.md
+++ b/www/README.md
@@ -1,6 +1,6 @@
 # Website
 
-This website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
+This website is built using [Docusaurus 3](https://docusaurus.io/), a modern static website generator.
 
 ## Installation
 

--- a/www/docusaurus.config.ts
+++ b/www/docusaurus.config.ts
@@ -318,10 +318,6 @@ const config: Config = {
           title: 'Community',
           items: [
             {
-              label: 'Twitter',
-              href: 'https://twitter.com/starknetjs',
-            },
-            {
               label: 'Discord',
               href: 'https://discord.com/channels/793094838509764618/1270119831559078061',
             },

--- a/www/src/pages/index.module.css
+++ b/www/src/pages/index.module.css
@@ -22,15 +22,18 @@
   justify-content: center;
 }
 
-.feedSection {
+.skillSection {
   padding: 3rem 0;
   background-color: #303846;
 }
-.feedContainer {
+.skillContainer {
   width: 90%;
-  max-width: 600px;
+  max-width: 800px;
   margin: auto;
+  text-align: left;
 }
-.twitterTarget {
-  color: white;
+.skillNote {
+  font-size: 0.85rem;
+  opacity: 0.8;
+  margin-bottom: 0;
 }

--- a/www/src/pages/index.module.css
+++ b/www/src/pages/index.module.css
@@ -16,6 +16,13 @@
   }
 }
 
+.heroLogo {
+  /* the image renders at its natural size (854x496); on short/wide screens
+     cap its height so the hero does not fill the whole viewport */
+  max-height: 40vh;
+  width: auto;
+}
+
 .buttons {
   display: flex;
   align-items: center;

--- a/www/src/pages/index.tsx
+++ b/www/src/pages/index.tsx
@@ -13,7 +13,7 @@ function HomepageHeader() {
   return (
     <header className={clsx('hero hero--primary', styles.heroBanner)}>
       <div className="container">
-        <img src={`${siteConfig.baseUrl}img/Starknet-JS_logo.png`} />
+        <img className={styles.heroLogo} src={`${siteConfig.baseUrl}img/Starknet-JS_logo.png`} />
         <p className="hero__subtitle">{siteConfig.tagline}</p>
         <div className={styles.buttons}>
           <Link className="button button--secondary button--lg" to="/docs/guides/intro">
@@ -50,7 +50,6 @@ function SkillSection() {
 }
 
 export default function Home(): JSX.Element {
-  const { siteConfig } = useDocusaurusContext();
   return (
     <Layout title={``} description="JavaScript library for Starknet">
       <HomepageHeader />

--- a/www/src/pages/index.tsx
+++ b/www/src/pages/index.tsx
@@ -1,8 +1,7 @@
-import BrowserOnly from '@docusaurus/BrowserOnly';
-import Head from '@docusaurus/Head';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import HomepageFeatures from '@site/src/components/HomepageFeatures';
+import CodeBlock from '@theme/CodeBlock';
 import Layout from '@theme/Layout';
 import clsx from 'clsx';
 import React from 'react';
@@ -26,29 +25,27 @@ function HomepageHeader() {
   );
 }
 
-function XFeed() {
+function SkillSection() {
   return (
-    <BrowserOnly>
-      {() => (
-        <div className={clsx('hero hero--primary', styles.heroBanner, styles.feedSection)}>
-          <div className={clsx(styles.feedContainer)}>
-            <a
-              className={clsx('twitter-timeline', styles.twitterTarget)}
-              data-width={600}
-              data-height={400}
-              data-dnt="true"
-              href="https://twitter.com/starknetjs?ref_src=twsrc%5Etfw"
-              style={{ textAlign: 'center' }}
-            >
-              Tweets by Starknetjs
-            </a>
-            <Head>
-              <script async src="https://platform.twitter.com/widgets.js" charSet="utf-8"></script>
-            </Head>
-          </div>
-        </div>
-      )}
-    </BrowserOnly>
+    <div className={clsx('hero hero--primary', styles.heroBanner, styles.skillSection)}>
+      <div className={clsx(styles.skillContainer)}>
+        <h2>Teach your AI coding agent starknet.js</h2>
+        <p>
+          AI training data is outdated — install the starknet.js skill to give your coding agent
+          accurate, up-to-date guidance. Works with Claude Code, Codex, Cursor, Gemini CLI, and any
+          other agent supporting the open skill standard.
+        </p>
+        <CodeBlock language="bash">npx skills add starknet-io/starknet.js</CodeBlock>
+        <p>or copy the skill files directly:</p>
+        <CodeBlock language="bash">
+          {'mkdir -p ~/.claude/skills/starknet-js && curl -s --output-dir ~/.claude/skills/starknet-js --remote-name-all "https://raw.githubusercontent.com/starknet-io/starknet.js/develop/skills/starknet-js/{SKILL.md,calldata.md,interacting.md}"'}
+        </CodeBlock>
+        <p className={styles.skillNote}>
+          This command installs into Claude Code&apos;s skills folder — adapt the target directory
+          for other agents.
+        </p>
+      </div>
+    </div>
   );
 }
 
@@ -58,7 +55,7 @@ export default function Home(): JSX.Element {
     <Layout title={``} description="JavaScript library for Starknet">
       <HomepageHeader />
       <main>
-        <XFeed></XFeed>
+        <SkillSection />
         <HomepageFeatures />
       </main>
     </Layout>


### PR DESCRIPTION
## Motivation and Resolution

The @starknetjs X (Twitter) account is no longer under the team's control, so the
X feed embedded in the documentation landing page and the remaining links to this
account had to be removed.

As a replacement, this PR introduces the official **starknet.js agent skill**
(`skills/starknet-js/`): three markdown files that teach AI coding agents
(Claude Code, Codex, Cursor, Gemini CLI…) how to correctly use starknet.js v10,
compensating for outdated training data. The skill follows the open
[Agent Skills](https://agentskills.io/) standard layout (`skills/<name>/SKILL.md`),
which makes it installable with `npx skills add starknet-io/starknet.js`
(verified end-to-end in an isolated environment), or by direct file copy with `curl`.

### RPC version (if applicable)

N/A — documentation-only change.

## Usage related changes

- Documentation landing page: the X feed is replaced by a "Teach your AI coding
  agent starknet.js" section with two copy-paste install commands (`npx skills add`
  and a `curl` one-liner), with a note to adapt the target folder for non-Claude agents.
- New `skills/starknet-js/` folder at the repo root: `SKILL.md`, `calldata.md`,
  `interacting.md`.
- New "🤖 Using AI" chapter in the root `README.md` with the same install commands.
- All links to the @starknetjs X account removed (docs footer, README badge).
- Landing page logo height is now capped (`max-height: 40vh`) so it no longer
  fills the whole viewport on wide screens.

## Development related changes

- `AGENTS.md`: contributors must keep `skills/starknet-js/` in sync when changing
  the public API surface.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] All tests are passing
