### PR TITLE
fix: ws bound reconnection of a flapping connection

### DIFF
--- a/__tests__/WebSocketChannel.reconnect.test.ts
+++ b/__tests__/WebSocketChannel.reconnect.test.ts
@@ -49,22 +49,27 @@ describe('Unit Test: WebSocketChannel auto-reconnection', () => {
 
       public onmessage: ((ev: Event) => void) | null = null;
 
+      private timers: NodeJS.Timeout[] = [];
+
       constructor(_url: string) {
         super();
         created += 1;
         current = this;
-        setTimeout(() => {
-          this.readyState = 1;
-          const ev = new Event('open');
-          this.onopen?.(ev);
-          this.dispatchEvent(ev);
-          if (behavior === 'flap') {
-            // Accept the connection then immediately drop it, as a rate-limiting
-            // gateway does. This used to reset the retry counter every cycle and
-            // reconnect forever.
-            setTimeout(() => this.emitClose(), 10);
-          }
-        }, 5);
+        this.timers.push(
+          setTimeout(() => {
+            if (this.readyState === 3) return; // closed before it could open
+            this.readyState = 1;
+            const ev = new Event('open');
+            this.onopen?.(ev);
+            this.dispatchEvent(ev);
+            if (behavior === 'flap') {
+              // Accept the connection then immediately drop it, as a rate-limiting
+              // gateway does. This used to reset the retry counter every cycle and
+              // reconnect forever.
+              this.timers.push(setTimeout(() => this.emitClose(), 10));
+            }
+          }, 5)
+        );
       }
 
       public send() {}
@@ -74,6 +79,8 @@ describe('Unit Test: WebSocketChannel auto-reconnection', () => {
       }
 
       public emitClose() {
+        this.timers.forEach(clearTimeout);
+        this.timers = [];
         if (this.readyState === 3) return;
         this.readyState = 3;
         const ev = new Event('close');

--- a/__tests__/WebSocketChannel.reconnect.test.ts
+++ b/__tests__/WebSocketChannel.reconnect.test.ts
@@ -1,0 +1,146 @@
+import { WebSocketChannel, config } from '../src';
+
+/**
+ * Unit tests for the auto-reconnection state machine, using a mock WebSocket
+ * implementation injected through `config.set('websocket', ...)`. No live node
+ * is required.
+ */
+describe('Unit Test: WebSocketChannel auto-reconnection', () => {
+  const wait = (ms: number) =>
+    new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    });
+
+  let originalLogLevel: ReturnType<typeof config.get>;
+
+  beforeAll(() => {
+    originalLogLevel = config.get('logLevel');
+    config.set('logLevel', 'OFF');
+  });
+
+  afterEach(() => {
+    config.set('websocket', undefined as any);
+  });
+
+  afterAll(() => {
+    config.set('logLevel', originalLogLevel as any);
+  });
+
+  /** Counts how many sockets get created, to detect a runaway reconnection loop. */
+  const makeMock = (behavior: 'flap' | 'stable') => {
+    let created = 0;
+    let current: any = null;
+    class MockWS extends EventTarget {
+      static CONNECTING = 0;
+
+      static OPEN = 1;
+
+      static CLOSING = 2;
+
+      static CLOSED = 3;
+
+      public readyState = 0;
+
+      public onopen: ((ev: Event) => void) | null = null;
+
+      public onclose: ((ev: Event) => void) | null = null;
+
+      public onerror: ((ev: Event) => void) | null = null;
+
+      public onmessage: ((ev: Event) => void) | null = null;
+
+      constructor(_url: string) {
+        super();
+        created += 1;
+        current = this;
+        setTimeout(() => {
+          this.readyState = 1;
+          const ev = new Event('open');
+          this.onopen?.(ev);
+          this.dispatchEvent(ev);
+          if (behavior === 'flap') {
+            // Accept the connection then immediately drop it, as a rate-limiting
+            // gateway does. This used to reset the retry counter every cycle and
+            // reconnect forever.
+            setTimeout(() => this.emitClose(), 10);
+          }
+        }, 5);
+      }
+
+      public send() {}
+
+      public close() {
+        this.emitClose();
+      }
+
+      public emitClose() {
+        if (this.readyState === 3) return;
+        this.readyState = 3;
+        const ev = new Event('close');
+        this.onclose?.(ev);
+        this.dispatchEvent(ev);
+      }
+    }
+    return {
+      MockWS,
+      get created() {
+        return created;
+      },
+      get current() {
+        return current as InstanceType<typeof MockWS>;
+      },
+    };
+  };
+
+  test('bounds a flapping connection instead of reconnecting forever', async () => {
+    const mock = makeMock('flap');
+    config.set('websocket', mock.MockWS as any);
+
+    const channel = new WebSocketChannel({
+      nodeUrl: 'wss://mock',
+      reconnectOptions: {
+        retries: 5,
+        delay: 50,
+        exponential: false,
+        stableConnectionThreshold: 2000,
+      },
+    });
+    await channel.waitForConnection().catch(() => undefined);
+
+    await wait(3000);
+
+    // 1 initial + at most `retries` reconnection attempts. Without the fix this
+    // grows without bound (hundreds within a few seconds).
+    expect(mock.created).toBeLessThanOrEqual(6);
+
+    channel.disconnect();
+  });
+
+  test('reconnects across repeated drops once each connection proves stable', async () => {
+    const mock = makeMock('stable');
+    config.set('websocket', mock.MockWS as any);
+
+    const channel = new WebSocketChannel({
+      nodeUrl: 'wss://mock',
+      reconnectOptions: {
+        retries: 3,
+        delay: 30,
+        exponential: false,
+        stableConnectionThreshold: 300,
+      },
+    });
+    await channel.waitForConnection();
+    expect(channel.isConnected()).toBe(true);
+
+    // Five drops, more than `retries`, each followed by a stable period. Each must
+    // reconnect: the counter resets after the connection stays open past the threshold.
+    for (let k = 0; k < 5; k += 1) {
+      mock.current.emitClose();
+      // eslint-disable-next-line no-await-in-loop
+      await wait(500);
+      expect(channel.isConnected()).toBe(true);
+    }
+
+    channel.disconnect();
+  });
+});

--- a/src/channel/ws/ws_0_10.ts
+++ b/src/channel/ws/ws_0_10.ts
@@ -428,8 +428,10 @@ export class WebSocketChannel {
       clearTimeout(this.reconnectStabilityTimeoutId);
       this.reconnectStabilityTimeoutId = null;
     }
-    this.websocket.close(code, reason);
+    // Set the flag before closing so the resulting `close` event does not trigger
+    // an automatic reconnection.
     this.userInitiatedClose = true;
+    this.websocket.close(code, reason);
   }
 
   /**

--- a/src/channel/ws/ws_0_10.ts
+++ b/src/channel/ws/ws_0_10.ts
@@ -89,6 +89,14 @@ export type ReconnectOptions = {
    * @default true
    */
   exponential?: number | boolean;
+  /**
+   * The minimum time in milliseconds a reconnected connection must stay open before
+   * it is considered stable and the retry counter is reset. This prevents a gateway
+   * that accepts the connection then immediately drops it (a "flapping" connection)
+   * from resetting the counter on every cycle and reconnecting forever.
+   * @default 5000
+   */
+  stableConnectionThreshold?: number;
 };
 
 /**
@@ -197,6 +205,10 @@ export class WebSocketChannel {
 
   private reconnectTimeoutId: NodeJS.Timeout | null = null;
 
+  // Fires once a (re)connection has stayed open long enough to be considered stable,
+  // resetting the reconnection attempt counter.
+  private reconnectStabilityTimeoutId: NodeJS.Timeout | null = null;
+
   private requestQueue: Array<{
     method: string;
     params?: object;
@@ -206,7 +218,12 @@ export class WebSocketChannel {
 
   private events = new EventEmitter<WebSocketChannelEvents>();
 
-  private openListener = (ev: Event) => this.events.emit('open', ev);
+  private openListener = (ev: Event) => {
+    // A connection is considered stable only after it has stayed open for a while;
+    // resetting the retry counter is deferred until then (see scheduleReconnectAttemptsReset).
+    this.scheduleReconnectAttemptsReset();
+    this.events.emit('open', ev);
+  };
 
   private closeListener = this.onCloseProxy.bind(this);
 
@@ -232,6 +249,7 @@ export class WebSocketChannel {
       retries: options.reconnectOptions?.retries ?? 5,
       delay: options.reconnectOptions?.delay ?? 2000,
       exponential: options.reconnectOptions?.exponential ?? true,
+      stableConnectionThreshold: options.reconnectOptions?.stableConnectionThreshold ?? 5000,
     };
     this.requestTimeout = options.requestTimeout ?? 60000;
 
@@ -406,6 +424,10 @@ export class WebSocketChannel {
       clearTimeout(this.reconnectTimeoutId);
       this.reconnectTimeoutId = null;
     }
+    if (this.reconnectStabilityTimeoutId) {
+      clearTimeout(this.reconnectStabilityTimeoutId);
+      this.reconnectStabilityTimeoutId = null;
+    }
     this.websocket.close(code, reason);
     this.userInitiatedClose = true;
   }
@@ -508,13 +530,34 @@ export class WebSocketChannel {
     await Promise.all(restorePromises);
   }
 
+  /**
+   * Reset the reconnection attempt counter, but only once the current connection has
+   * stayed open for `stableConnectionThreshold` ms. A connection that opens and then
+   * immediately drops (a flapping gateway) never reaches this point, so its attempts
+   * keep accumulating toward the retry cap instead of resetting every cycle.
+   */
+  private scheduleReconnectAttemptsReset() {
+    if (this.reconnectStabilityTimeoutId) {
+      clearTimeout(this.reconnectStabilityTimeoutId);
+    }
+    this.reconnectStabilityTimeoutId = setTimeout(() => {
+      this.reconnectAttempts = 0;
+      this.reconnectStabilityTimeoutId = null;
+    }, this.reconnectOptions.stableConnectionThreshold);
+  }
+
   private _startReconnect() {
     if (this.isReconnecting || !this.autoReconnect) {
       return;
     }
 
+    // The connection that just dropped did not prove stable, so cancel any pending
+    // counter reset and keep the accumulated attempts (bounds a flapping reconnect).
+    if (this.reconnectStabilityTimeoutId) {
+      clearTimeout(this.reconnectStabilityTimeoutId);
+      this.reconnectStabilityTimeoutId = null;
+    }
     this.isReconnecting = true;
-    this.reconnectAttempts = 0;
 
     const tryReconnect = () => {
       if (this.reconnectAttempts >= this.reconnectOptions.retries) {
@@ -533,7 +576,8 @@ export class WebSocketChannel {
       this.websocket.onopen = async () => {
         logger.info('WebSocket: Reconnection successful.');
         this.isReconnecting = false;
-        this.reconnectAttempts = 0;
+        // The attempt counter is reset by the openListener's stability timer, not here:
+        // a reconnection that drops again before proving stable must keep its count.
         await this._restoreSubscriptions();
         this._processRequestQueue();
         // Manually trigger the onOpen listeners as the original 'open' event was consumed.


### PR DESCRIPTION
## Motivation and Resolution

The WebSocket auto-reconnection could spawn connections without bound. When a gateway
accepts the socket upgrade and then immediately drops the connection (a "flapping"
connection — e.g. a rate-limiting gateway under load), every successful `open` reset the
reconnection attempt counter, so the channel never reached its retry cap and reconnected
forever. In practice this created hundreds of sockets per second and crashed the process
with `JavaScript heap out of memory`.

Two fixes:

1. The attempt counter is now reset only once a (re)connection has stayed open for a
   minimum duration (`stableConnectionThreshold`, default 5000 ms). A connection that
   drops before proving stable keeps its accumulated attempts, so a flapping connection is
   bounded by `retries` and eventually gives up — while a genuinely healthy connection
   still resets its counter and reconnects normally on future drops.
2. `disconnect()` now sets its user-initiated flag *before* closing the socket, so the
   resulting `close` event can no longer trigger an automatic reconnection.

### RPC version (if applicable)

N/A — affects the WebSocket channel regardless of RPC spec version.

## Usage related changes

- `ReconnectOptions` gains an optional `stableConnectionThreshold` field (milliseconds,
  default `5000`): the minimum time a reconnected connection must stay open before the
  retry counter is reset. Existing code is unaffected by default.
- A flapping connection now stops after `retries` attempts instead of reconnecting
  indefinitely.
- `disconnect()` reliably prevents auto-reconnection, even if the underlying socket
  reports its closure synchronously.

## Development related changes

- Added `__tests__/WebSocketChannel.reconnect.test.ts`: unit tests using a mock WebSocket
  (no live node needed, so they run in the fast devnet job too) that assert (1) a flapping
  connection is bounded instead of looping forever, and (2) a connection that proves stable
  between drops reconnects on every drop.

## Checklist:

- [x] Performed a self-review of the code
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
