### PR TITLE
test: fix rated limitations of Zan node

### DIFF
--- a/__tests__/defaultNodes.test.ts
+++ b/__tests__/defaultNodes.test.ts
@@ -36,6 +36,64 @@ describe('unit tests', () => {
   });
 });
 
+// JSON-RPC error code returned by some public nodes (e.g. ZAN) when we exceed
+// their per-second request quota. It is a transient rate-limit, not a lack of
+// spec-version support, so it must not be counted as a node failure.
+const RATE_LIMIT_ERROR_CODE = -32011;
+
+const sleep = (ms: number) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+/**
+ * A transient error is one worth retrying: a rate-limit, or a network timeout.
+ * A node that genuinely does not support the spec version fails differently.
+ */
+function isTransientError(error: any): boolean {
+  if (error?.code === RATE_LIMIT_ERROR_CODE) return true;
+  const name = String(error?.name ?? '');
+  const message = String(error?.message ?? '').toLowerCase();
+  return name === 'AbortError' || message.includes('timeout') || message.includes('fetch failed');
+}
+
+/**
+ * Resolve the spec version of a node, retrying on transient errors with
+ * exponential backoff. Returns:
+ *  - the version string on success,
+ *  - `'rate-limited'` if every attempt was rejected by a rate-limit,
+ *  - `undefined` for any genuine failure (unsupported spec, malformed response...).
+ */
+async function getSpecVersionWithRetry(
+  provider: InstanceType<typeof Provider>,
+  nodeUrl: string,
+  retries = 3
+): Promise<string | undefined> {
+  let lastError: any;
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      return await provider.getSpecVersion();
+    } catch (error) {
+      lastError = error;
+      if (!isTransientError(error) || attempt === retries) break;
+      // eslint-disable-next-line no-await-in-loop
+      await sleep(500 * 2 ** attempt); // 500ms, 1s, 2s
+    }
+  }
+
+  if (lastError?.code === RATE_LIMIT_ERROR_CODE) {
+    // eslint-disable-next-line no-console
+    console.warn(`[defaultNodes] SKIP ${nodeUrl} | rate-limited after ${retries + 1} attempts`);
+    return 'rate-limited';
+  }
+  // eslint-disable-next-line no-console
+  console.error(
+    `[defaultNodes] FAIL ${nodeUrl} | err=${lastError?.name}: ${lastError?.message} (code=${lastError?.code})`
+  );
+  return undefined;
+}
+
 describe('Default RPC Nodes', () => {
   test('All Default RPC Nodes support Spec Versions', async () => {
     const supportedVersions = getSupportedRpcVersions();
@@ -48,36 +106,7 @@ describe('Default RPC Nodes', () => {
             return Promise.all(
               rpcNodes[network as keyof typeof rpcNodes].map(async (it: any) => {
                 const provider = new Provider({ nodeUrl: it });
-                let version;
-                try {
-                  version = await provider.getSpecVersion();
-                } catch (error) {
-                  // TEMPORARY DIAGNOSTIC: surface the swallowed error so CI logs reveal
-                  // whether the failure is a rate-limit (HTTP 429), a timeout, or a 5xx.
-                  // The channel does not expose the HTTP status (it calls response.json()
-                  // directly), so we log the raw error AND re-probe to read response.status.
-                  const e = error as any;
-                  let probe: string;
-                  try {
-                    const r = await fetch(it, {
-                      method: 'POST',
-                      headers: { 'Content-Type': 'application/json' },
-                      body: JSON.stringify({
-                        id: 1,
-                        jsonrpc: '2.0',
-                        method: 'starknet_specVersion',
-                      }),
-                    });
-                    probe = `status=${r.status} ${r.statusText}; body="${(await r.text()).slice(0, 120)}"`;
-                  } catch (probeErr: any) {
-                    probe = `probe failed: ${probeErr?.name}: ${probeErr?.message}`;
-                  }
-                  // eslint-disable-next-line no-console
-                  console.error(
-                    `[defaultNodes] FAIL ${it} | err=${e?.name}: ${e?.message} (code=${e?.code}) | probe=${probe}`
-                  );
-                  version = undefined;
-                }
+                const version = await getSpecVersionWithRetry(provider, it);
 
                 return {
                   network,


### PR DESCRIPTION
## Motivation and Resolution

The `defaultNodes.test.ts` test ("All Default RPC Nodes support Spec Versions") was
intermittently failing in the Devnet CI workflow. The previously merged diagnostic
logging (#1648) confirmed the root cause: the public ZAN node
(`https://api.zan.top/public/starknet-sepolia/rpc/v0_10`) rejects bursts of requests
with a proprietary JSON-RPC error `-32011: cu limit exceeded; Request too fast per
second`, while an immediate re-probe returns `200` with a valid
`result: "0.10.3-rc.0"`.

In other words, the node **does** support the spec version — it was only rate-limiting
us because the test fires every (version × network × node) request in parallel via
nested `Promise.all`. The test wrongly counted the rate-limit response as
`version = undefined`, i.e. "node does not support the spec version", and failed.

This PR removes the temporary diagnostic block and replaces it with resilient logic:

- `getSpecVersionWithRetry()` retries up to 3 times with exponential backoff
  (500ms → 1s → 2s), but **only** on transient errors (`isTransientError`: rate-limit
  code `-32011`, `AbortError`, timeouts, `fetch failed`).
- If a node is still rate-limited after every attempt, it is logged as a `SKIP`
  (`console.warn`) and returns a non-`undefined` value, so it is **not** counted as a
  failure.
- Any genuine failure (unsupported spec, malformed response, non-transient error) still
  logs a `FAIL` (`console.error`) and returns `undefined`, keeping the test's original
  fail behavior.

The rate-limit code is isolated in the `RATE_LIMIT_ERROR_CODE` constant so it can be
extended if another provider uses a different code.

### RPC version (if applicable)

N/A — test-only change, no impact on the library's RPC handling.

## Usage related changes

- None. This change only affects the test suite; no public API or runtime behavior is
  modified.

## Development related changes

- `defaultNodes.test.ts` no longer fails on transient rate-limiting from public default
  nodes, removing a recurring source of CI flakiness in the Devnet workflow.
- Removed the temporary diagnostic (raw error logging + HTTP re-probe) introduced for
  debugging.
- A node distinguishes three outcomes: success (version string), rate-limited
  (tolerated `SKIP`), and genuine failure (`FAIL`).

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
