### PR TITLE
fix: publish the 10.5.x line to the stable npm latest channel

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ export * from './utils/units';
 export * as wallet from './wallet/connect';
 export * as walletV5 from './wallet/connectV5';
 export * as walletV6 from './wallet/connectV6';
+
 export * from './global/config';
 export * from './global/logger';
 export * from './global/logger.type';


### PR DESCRIPTION
Forces a fresh publish so the 10.5 line reaches the npm latest dist-tag (NPM_TOKEN for dist-tag promotion is expired).