### PR TITLE
docs: fix error in Enum guide- parameters of CallData.compile

### DIFF
--- a/www/docs/guides/contracts/cairo_enum.md
+++ b/www/docs/guides/contracts/cairo_enum.md
@@ -281,6 +281,6 @@ const myCustomEnum = new CairoCustomEnum({
   Critical: undefined,
   Empty: undefined,
 });
-const myCalldata = CallData.compile(myCustomEnum);
+const myCalldata = CallData.compile([myCustomEnum]);
 const res = (await myTestContract.call('test2a', myCalldata)) as bigint;
 ```


### PR DESCRIPTION
## Motivation and Resolution

The Cairo Enums guide showed `CallData.compile(myCustomEnum)` passing a `CairoCustomEnum` instance directly (without an ABI). In starknet.js v10 this throws `undefined can't be computed by felt()`, because the static `CallData.compile` treats the instance as an object whose `undefined` variants (`Response`, `Warning`, `Critical`, `Empty`) are each interpreted as a parameter.

The enum must be wrapped in an array so it is recognized as a single enum parameter. This PR fixes the example to `CallData.compile([myCustomEnum])`, which correctly serializes to `["2", "100", "110"]` (variant index 2 = `Error`, plus the `(100, 110)` tuple). This is also consistent with the rest of the guide, which already uses the bracketed form everywhere else.

### RPC version (if applicable)

N/A — documentation-only change.

## Usage related changes

- Fixed the Cairo custom Enum example in the docs guide (`www/docs/guides/contracts/cairo_enum.md`): `CallData.compile(myCustomEnum)` → `CallData.compile([myCustomEnum])`. Users copy-pasting the previous snippet no longer hit `undefined can't be computed by felt()`.

## Development related changes

- None.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] All tests are passing
