### PR TITLE
fix(plugins): export starknetId factory as starknetIdPlugin

### DIFF
--- a/src/plugins/fast-execute/index.ts
+++ b/src/plugins/fast-execute/index.ts
@@ -22,7 +22,6 @@ import type {
  * @example
  * ```typescript
  * import { RpcProvider, Account } from 'starknet';
- * import { fastExecute } from 'starknet/plugins';
  *
  * const provider = new RpcProvider({
  *   nodeUrl: url,

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -5,8 +5,14 @@ export type { StarknetPlugin, ProviderHooks, AccountHooks, PluginConfig } from '
 export { PluginManager } from './manager';
 
 // Plugin implementations
+//
+// The StarknetId factory is exported as `starknetIdPlugin` and NOT as `starknetId`:
+// the bare name is already taken at the package root by the `starknetId` utility
+// namespace (`export * as starknetId from './utils/starknetId'` in `src/index.ts`).
+// An explicit export always wins over a wildcard re-export, so a factory exported
+// here as `starknetId` would be silently dropped from the built bundle.
 export {
-  starknetId,
+  starknetId as starknetIdPlugin,
   StarknetIdImpl,
   type StarknetIdProviderMethods,
   type StarknetIdAccountMethods,

--- a/src/plugins/starknet-id/index.ts
+++ b/src/plugins/starknet-id/index.ts
@@ -299,10 +299,13 @@ export class StarknetIdImpl {
 /**
  * StarknetId plugin - adds domain name resolution methods.
  *
+ * Exported from the package root as `starknetIdPlugin`, because the bare
+ * `starknetId` name is taken by the utility namespace.
+ *
  * @example
  * ```typescript
- * import { RpcProvider, starknetId } from 'starknet';
- * const provider = new RpcProvider({ plugins: [starknetId()] });
+ * import { RpcProvider, starknetIdPlugin } from 'starknet';
+ * const provider = new RpcProvider({ plugins: [starknetIdPlugin()] });
  * const name = await provider.getStarkName('0x123...');
  * ```
  */

--- a/www/docs/guides/plugins.md
+++ b/www/docs/guides/plugins.md
@@ -40,13 +40,13 @@ const myName = await account.getStarkName();
 ## Choosing Plugins
 
 ```typescript
-import { RpcProvider, starknetId, brotherId, defaultPlugins } from 'starknet';
+import { RpcProvider, starknetIdPlugin, brotherId, fastExecute, defaultPlugins } from 'starknet';
 
 // No plugins — plugin methods throw
 const bare = new RpcProvider({ nodeUrl, plugins: false });
 
 // Only specific plugins
-const provider = new RpcProvider({ nodeUrl, plugins: [starknetId()] });
+const provider = new RpcProvider({ nodeUrl, plugins: [starknetIdPlugin()] });
 
 // Default plugins + your own
 const custom = new RpcProvider({
@@ -54,6 +54,13 @@ const custom = new RpcProvider({
   plugins: [...defaultPlugins, myCustomPlugin()],
 });
 ```
+
+:::note
+The StarknetId plugin factory is exported as **`starknetIdPlugin`**, not `starknetId`: the
+bare `starknetId` name is already used by the utility namespace (`starknetId.useEncoded`,
+`starknetId.isStarkDomain`, ...). The two other factories keep their plain names,
+`brotherId()` and `fastExecute()`.
+:::
 
 The same `plugins` option is available on `Account`.
 
@@ -64,7 +71,7 @@ Add plugins after construction with `.use()`. TypeScript infers the added method
 ```typescript
 const provider = new RpcProvider({ nodeUrl, plugins: false });
 
-const extended = provider.use(starknetId());
+const extended = provider.use(starknetIdPlugin());
 await extended.getStarkName(address); // ✅ fully typed
 ```
 


### PR DESCRIPTION
## Motivation and Resolution

The `starknetId()` plugin factory was unreachable from the published package.

`src/index.ts` exported two symbols under the same `starknetId` name:

- `export * from './plugins';` (line 11) — re-exported the plugin factory
- `export * as starknetId from './utils/starknetId';` (line 32) — the utility namespace

An explicit export always wins over a wildcard re-export, so the factory was silently
dropped when tsup flattened the re-exports into a single bundle. Checked on the built
output:

```bash
node -e "const s=require('./dist/index.js'); console.log(typeof s.starknetId, typeof s.brotherId, typeof s.fastExecute)"
# -> object function function
```

`brotherId()` and `fastExecute()` were fine; only `starknetId()` was lost. `dist/index.d.ts`
listed a single `starknetId` in its `export { ... }` block: the namespace. As a result,
`plugins: [starknetId()]` threw `TypeError: starknetId is not a function` for every consumer
of the npm package, and the only workaround was `defaultPlugins`.

Nothing reproduced this from the sources — the bug only exists in the flattened bundle, so a
unit test importing from `src/` would have stayed green.

**Resolution:** the factory is now re-exported as `starknetIdPlugin` in `src/plugins/index.ts`.
The bare `starknetId` name no longer appears in the plugins barrel, so the collision cannot
happen at all — it is removed rather than worked around. A comment on the export records why,
so the asymmetry is not "fixed" later without context.

Subpath exports (`starknet/plugins/...`) were considered and rejected: `package.json` only
declares `"."` in `exports`, and adding real subpaths would mean multiple tsup entries,
duplicated runtime across bundles and a larger package — disproportionate for a name clash.

### RPC version (if applicable)

Not applicable.

## Usage related changes

- The StarknetId plugin factory is now exported from the package root as **`starknetIdPlugin`**.
  `plugins: [starknetIdPlugin()]` and `provider.use(starknetIdPlugin())` work as documented.
- No breaking change: the removed name was unreachable in every published build, and the
  `starknetId` utility namespace (`useEncoded`, `useDecoded`, `isStarkDomain`, ...) is untouched.
- `brotherId()` and `fastExecute()` keep their plain names. The asymmetry is intentional and
  documented — `starknetId` is taken by the utility namespace.
- Fixed two JSDoc examples that showed import paths which do not resolve:
  `starknet/plugins/starknet-id` and `starknet/plugins`. The `fastExecute` example also carried
  a superfluous import, since it relies on the default plugins.
- Updated the plugin guide (`www/docs/guides/plugins.md`) with the correct import and a note
  explaining the naming.

## Development related changes

- None. No build, test or CI configuration was touched.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] All tests are passing
