### PR TITLE
docs: complete and fix the v9 ->  v10 migration guide

### DIFF
--- a/src/utils/stark/index.ts
+++ b/src/utils/stark/index.ts
@@ -134,7 +134,7 @@ export function randomAddress(): string {
  * ```typescript
  * const proofArray = [1, 2, 3, 4, 5];
  * const result = stark.encodeProof(proofArray);
- * // result = "AQAAAAIAAAADAAAABAAAAAUAAAAv"
+ * // result = "AQAAAAIAAAADAAAABAAAAAUAAAA="
  * ```
  */
 export function encodeProof(proof: number[]): string {
@@ -147,7 +147,7 @@ export function encodeProof(proof: number[]): string {
  * @returns {number[]} Array of proof integers
  * @example
  * ```typescript
- * const proofBase64 = "AQAAAAIAAAADAAAABAAAAAUAAAAv";
+ * const proofBase64 = "AQAAAAIAAAADAAAABAAAAAUAAAA=";
  * const result = stark.decodeProof(proofBase64);
  * // result = [1, 2, 3, 4, 5]
  * ```

--- a/www/docs/guides/migrate.md
+++ b/www/docs/guides/migrate.md
@@ -14,31 +14,38 @@ If you encounter any missing changes, please let us know and we will update this
 
 1. **Account Composition** - Account no longer extends Provider, uses composition instead
 2. **Plugin Class Names** - `StarknetId` → `StarknetIdImpl`, `BrotherId` → `BrotherIdImpl`
-3. **Plugin Import Paths** - `provider/extensions/` → `plugins/`
+3. **Plugin Import Paths** - `provider/extensions/` → package root
 4. **Compression Functions** - `compressProgram()` and `decompressProgram()` are now async
 5. **SimulateTransaction Response** - `SimulateTransactionOverheadResponse` changed from array to object
 6. **Provider fetch() Method** - Now `async` (low impact)
 7. **Removed Global Singletons** - `defaultProvider` and `defaultPaymaster` removed, use `RpcProvider.create()` instead
 8. **ts-mixer Removed** - No longer a dependency
 9. **getStorageAt() Return Type** - Now returns `STORAGE_RESULT` object instead of `string`
-10. **Transaction proof Field** - Now `string` (base64) instead of `number[]`
+10. **fastExecute Moved to a Plugin** - `account.fastExecute()` and `provider.fastWaitForTransaction()` now come from the `fastExecute` plugin
+11. **Paymaster Option Renamed** - `PaymasterRpcOptions.default` → `mute`
+12. **felt252 Validation** - `CairoFelt()` now throws on out-of-range values, and `CairoFelt252.toApiRequest()` returns decimal
+13. **RPC Namespace Renames** - `RPCSPEC010` → `RPCSPEC0103`, `RPC010` → `RPC0102` / `RPC0103`
 
 ### Breaking Changes Summary
 
-| Change                                                           | Severity   | Impact                                                   |
-| ---------------------------------------------------------------- | ---------- | -------------------------------------------------------- |
-| Account composition (`account.xyz()` → `account.provider.xyz()`) | **High**   | All provider method calls on Account must be updated     |
-| Removed `defaultProvider` and `defaultPaymaster` singletons      | **Medium** | Use `await RpcProvider.create()` or `new PaymasterRpc()` |
-| `getStorageAt()` returns object instead of string                | **Medium** | Must use `.value` property to access FELT value          |
-| Transaction `proof` field is base64 string instead of array      | **Medium** | Encode `number[]` to base64 string when constructing tx  |
-| Compression functions now async (`await compressProgram()`)      | **Medium** | Only if using compress/decompress functions directly     |
-| Plugin class renames (`StarknetId` → `StarknetIdImpl`)           | **Medium** | Only affects direct imports of these classes             |
-| Plugin import paths (`extensions/` → `plugins/`)                 | **Medium** | Only affects direct imports                              |
-| `SimulateTransactionOverheadResponse` is now an object           | **Medium** | Must access `.simulated_transactions` for the array      |
-| Removed `default` parameter from RPC options                     | **Low**    | Parameter was only used by removed singletons            |
-| `fetch()` is now `async`                                         | **Low**    | Already returned Promise, minimal impact                 |
-| `ts-mixer` removed                                               | **Low**    | Only affects if you used it as transitive dependency     |
-| `plugins: false` disables defaults                               | **Info**   | Behavioral change, intentional opt-out                   |
+| Change                                                           | Severity   | Impact                                                    |
+| ---------------------------------------------------------------- | ---------- | --------------------------------------------------------- |
+| Account composition (`account.xyz()` → `account.provider.xyz()`) | **High**   | All provider method calls on Account must be updated      |
+| Removed `defaultProvider` and `defaultPaymaster` singletons      | **Medium** | Use `await RpcProvider.create()` or `new PaymasterRpc()`  |
+| `getStorageAt()` returns object instead of string                | **Medium** | Must use `.value` property to access FELT value           |
+| Compression functions now async (`await compressProgram()`)      | **Medium** | Also `parseContract()` and the contract-class helpers     |
+| Plugin class renames (`StarknetId` → `StarknetIdImpl`)           | **Medium** | Only affects direct imports of these classes              |
+| Plugin import paths (`extensions/` → package root)               | **Medium** | Only affects direct imports                               |
+| `SimulateTransactionOverheadResponse` is now an object           | **Medium** | Must access `.simulated_transactions` for the array       |
+| `fastExecute` is now a plugin                                    | **Medium** | Types renamed; methods disappear with `plugins: false`    |
+| `RPCSPEC010` / `RPC010` namespaces renamed                       | **Medium** | Only affects raw spec types and direct channel imports    |
+| `PaymasterRpcOptions.default` renamed to `mute`                  | **Low**    | Only affects manual `PaymasterRpc` construction           |
+| felt252 range validation is now enforced                         | **Low**    | Out-of-range values used to pass silently, they now throw |
+| `Storage` response type renamed to `StorageResponse`             | **Low**    | Only affects code importing the type                      |
+| Removed `default` parameter from RPC options                     | **Low**    | Parameter was only used by removed singletons             |
+| `fetch()` is now `async`                                         | **Low**    | Already returned Promise, minimal impact                  |
+| `ts-mixer` and `pako` removed                                    | **Low**    | Only affects if you used them as transitive dependencies  |
+| `plugins: false` disables defaults                               | **Info**   | Behavioral change, intentional opt-out                    |
 
 **Quick migration steps:**
 
@@ -71,7 +78,7 @@ In v9, `Account` extended `Provider`, giving direct access to all provider metho
 **❌ v9 (no longer works):**
 
 ```typescript
-const account = new Account(provider, address, privateKey);
+const account = new Account({ provider, address, signer: privateKey });
 
 await account.waitForTransaction(txHash);
 await account.getBlock('latest');
@@ -81,7 +88,7 @@ await account.getChainId();
 **✅ v10:**
 
 ```typescript
-const account = new Account(provider, address, privateKey);
+const account = new Account({ provider, address, signer: privateKey });
 
 // Provider methods now require .provider
 await account.provider.waitForTransaction(txHash);
@@ -252,23 +259,26 @@ import { StarknetId } from 'starknet/provider/extensions/starknetId';
 ```typescript
 import { StarknetIdImpl } from 'starknet';
 // Or, for the plugin factory (see "Disabling or Customizing Plugins" below):
-import { starknetId } from 'starknet/plugins/starknet-id';
+import { starknetIdPlugin } from 'starknet';
 ```
 
 :::caution
-`import { starknetId } from 'starknet'` gives the **utility namespace** (same as in v9), not the plugin factory function. Use `'starknet/plugins/starknet-id'` when you need to pass `starknetId()` to the `plugins` option.
+The StarknetId plugin factory is named **`starknetIdPlugin`**, not `starknetId`: the bare
+`starknetId` name is already taken by the utility namespace (`starknetId.useEncoded`,
+`starknetId.isStarkDomain`, ...), exactly as in v9. The two other factories keep their plain
+names, `brotherId()` and `fastExecute()`.
 :::
 
 ### Default Behavior
 
-**Good news:** For most users, plugins work the same way. StarknetId and BrotherId plugins are **automatically installed** by default:
+**Good news:** For most users, plugins work the same way. The StarknetId, BrotherId and fastExecute plugins are **automatically installed** by default:
 
 ```typescript
 // These work out of the box in v10 (no changes needed)
 const provider = new RpcProvider({ nodeUrl });
 await provider.getStarkName(address); // ✅ Works
 
-const account = new Account(provider, address, privateKey);
+const account = new Account({ provider, address, signer: privateKey });
 await account.getStarkName(); // ✅ Works
 ```
 
@@ -283,12 +293,12 @@ const provider = new RpcProvider({
   plugins: false,
 });
 
-// Use specific plugins only — import the factory from its sub-path
-import { starknetId } from 'starknet/plugins/starknet-id';
+// Use specific plugins only
+import { starknetIdPlugin, brotherId, fastExecute } from 'starknet';
 
 const provider = new RpcProvider({
   nodeUrl,
-  plugins: [starknetId()],
+  plugins: [starknetIdPlugin()],
 });
 
 // Add custom plugins
@@ -375,7 +385,9 @@ const decompressed = await stark.decompressProgram(compressed);
 **Who is affected:**
 
 - Users manually compressing/decompressing Cairo 0 programs
-- Users calling `parseContract()` directly (also now async)
+- Users calling one of the contract-class helpers that internally compress, which became async
+  for the same reason: `parseContract()`, `createSierraContractClass()` and
+  `contractClassResponseToLegacyCompiledContract()`
 - Advanced use cases involving manual contract compilation
 
 **Who is NOT affected:**
@@ -398,6 +410,22 @@ async function processContract(program) {
   const compressed = await stark.compressProgram(program);
   return compressed;
 }
+```
+
+The same applies to the contract-class helpers:
+
+```typescript
+import { provider, contractClassResponseToLegacyCompiledContract } from 'starknet';
+
+// Before (v9)
+const contractClass = provider.parseContract(compiledContract);
+const sierra = provider.createSierraContractClass(compiledSierra);
+const legacy = contractClassResponseToLegacyCompiledContract(response);
+
+// After (v10)
+const contractClass = await provider.parseContract(compiledContract);
+const sierra = await provider.createSierraContractClass(compiledSierra);
+const legacy = await contractClassResponseToLegacyCompiledContract(response);
 ```
 
 ## Breaking Change 6: SimulateTransaction Response Structure
@@ -489,16 +517,17 @@ If your code didn't directly use `ts-mixer`, no changes are needed. If you were 
 
 ### What Changed
 
-The `getStorageAt()` method now returns a `STORAGE_RESULT` object instead of a plain string.
+The `getStorageAt()` method now returns a `STORAGE_RESULT` object instead of a plain string. The
+response type exported by the library was renamed accordingly: `Storage` → `StorageResponse`.
 
-**❌ v10.0.0:**
+**❌ v9:**
 
 ```typescript
 const value = await provider.getStorageAt(address, key);
 const felt = BigInt(value); // ✗ Error: value is now an object
 ```
 
-**✅ v10.0.1+:**
+**✅ v10:**
 
 ```typescript
 const result = await provider.getStorageAt(address, key);
@@ -533,129 +562,102 @@ const { value, last_update_block } = await provider.getStorageAt(addr, key);
 const felt = BigInt(value);
 ```
 
-## Breaking Change 9: Transaction proof Field Type
+If you imported the response type, rename it:
 
-**⚠️ REQUIRED CHANGE** - Proof must be base64 encoded string. TypeScript will error if you pass number[].
+```typescript
+import type { StorageResponse } from 'starknet'; // ✅ Was `Storage`
+```
+
+## Breaking Change 9: fastExecute Is Now a Plugin
 
 ### What Changed
 
-The `proof` field in transactions changed from `number[]` (array of numbers) to `string` (base64-encoded).
+In v9, `fastExecute()` was a native `Account` method and `fastWaitForTransaction()` a native
+`RpcProvider` method. In v10 both come from the `fastExecute` plugin, which is part of
+`defaultPlugins`.
 
-**❌ v9.x (No longer works)**
-
-```typescript
-const invocation = {
-  type: 'INVOKE',
-  proof: [1, 2, 3, 4], // ✗ Type Error: number[] not assignable to string
-};
-```
-
-**✅ v10.0.1+ (Required approach)**
+**Good news:** with the default configuration, nothing changes:
 
 ```typescript
-import { stark } from 'starknet';
-
-// Step 1: MUST encode array to base64 before any method call
-const proofBase64 = stark.encodeProof([1, 2, 3, 4]);
-// result = "AQAAAAIAAAADAAAABAAAAAUAAAAv"
-
-// Step 2: Pass encoded string
-await account.execute(calls, {
-  proof: proofBase64, // ✓ Must be base64 string
-});
+// Still works out of the box in v10
+const resp = await account.fastExecute(call, { tip }, { retries: 30, retryInterval: 500 });
 ```
 
-### Why This Change?
-
-The RPC specification now requires proofs to be encoded as base64 strings of big-endian packed u32 values for consistency with the network.
-
-### Migration Guide
-
-**Required:** Use `stark.encodeProof()` to convert number arrays to base64 before calling any Account method:
+**❌ Breaks if you opted out of plugins:**
 
 ```typescript
-import { stark } from 'starknet';
-
-// REQUIRED: Convert to base64
-const proofBase64 = stark.encodeProof(proofArray);
-
-// Then pass to Account methods
-await account.execute(calls, { proof: proofBase64 });
-await account.estimateInvokeFee(calls, { proof: proofBase64 });
-await account.simulateTransaction(invocations, { proof: proofBase64 });
+const account = new Account({ provider, address, signer, plugins: false });
+await account.fastExecute(call); // ✗ Method does not exist anymore
 ```
 
-**Optional:** Decode if you need to convert back
+Re-add the plugin explicitly when you disable the defaults:
 
 ```typescript
-// If needed, decode base64 back to number array
-const proofArray = stark.decodeProof(proofBase64);
+import { fastExecute } from 'starknet';
+
+const account = new Account({ provider, address, signer, plugins: [fastExecute()] });
 ```
 
-### New: `proofFacts` Field
+### Type Renames
 
-v10 also introduces an optional `proofFacts` field alongside `proof`. When present, it changes the v3 transaction hash computation (the Poseidon of all proof facts is folded into the hash).
+The two related types were renamed to follow the naming convention:
 
 ```typescript
-// proofFacts is optional — pass only when your SNIP-36 off-chain computation
-// produces facts that must be committed on-chain
-await account.execute(calls, {
-  proof: proofBase64, // base64-encoded proof (see above)
-  proofFacts: [fact1, fact2], // BigNumberish[] — omit if unused
-});
+import type { FastExecuteResponse } from 'starknet'; // ✅ Was fastExecuteResponse
+import type { FastWaitForTransactionOptions } from 'starknet'; // ✅ Was fastWaitForTransactionOptions
 ```
 
-:::note
-`proofFacts` is additive — existing code without it continues to work unchanged. Only set it when your use case requires SNIP-36 fact commitment.
-:::
+Method signatures are unchanged.
 
-## Migration Checklist
+## Breaking Change 10: Paymaster `default` Option Renamed
 
-When upgrading from v9 to v10:
+### What Changed
 
-- [ ] Update `starknet` package to v10.x
-- [ ] **Account Composition:**
-  - [ ] Find all `account.xyz()` calls where `xyz` is a provider method
-  - [ ] Replace with `account.provider.xyz()`
-  - [ ] Verify account-specific methods (`execute`, `signMessage`, etc.) still work directly
-- [ ] **Plugin System:**
-  - [ ] Update plugin imports: `StarknetId` → `StarknetIdImpl` (if importing directly)
-  - [ ] Update plugin imports: `BrotherId` → `BrotherIdImpl` (if importing directly)
-  - [ ] Update import paths: `starknet/provider/extensions/` → `starknet/plugins/`
-  - [ ] Test that plugin methods still work: `getStarkName()`, `getAddressFromStarkName()`, etc.
-  - [ ] If using `plugins: false`, verify this is intentional (disables StarknetId/BrotherId)
-- [ ] **Compression Functions:**
-  - [ ] Search for `compressProgram()` calls and add `await`
-  - [ ] Search for `decompressProgram()` calls and add `await`
-  - [ ] Search for `parseContract()` calls and add `await` (if used directly)
-  - [ ] Make calling functions `async` if they weren't already
-- [ ] **Provider Changes:**
-  - [ ] Review any code using `provider.fetch()` with `.then()` chains
-  - [ ] Verify error handling still works correctly
-- [ ] **Storage Queries:**
-  - [ ] Find all `getStorageAt()` calls
-  - [ ] Update usage from `BigInt(result)` to `BigInt(result.value)`
-  - [ ] Optionally use `result.last_update_block` if you need metadata
-- [ ] **Transaction Proofs:** ⚠️ REQUIRED
-  - [ ] Find all places where `proof` is used in Account methods
-  - [ ] Convert `number[]` to base64 string using `stark.encodeProof(proofArray)`
-  - [ ] Pass the encoded string: `Account.execute({ ..., proof: encodedProofString })`
-  - [ ] TypeScript will error if proof is still a number[] array
-- [ ] **SimulateTransaction Response:**
-  - [ ] Find all `getSimulateTransaction()` calls
-  - [ ] Replace direct array access (e.g., `result[0]`, `result.map()`) with `result.simulated_transactions[0]`, `result.simulated_transactions.map()`
-  - [ ] Optionally use `result.initial_reads` if using `returnInitialReads` option
-- [ ] **Dependencies:**
-  - [ ] Remove any references to `ts-mixer` if you were using it
-  - [ ] If you depended on `ts-mixer` transitively, add it to your `package.json`
-- [ ] **Custom Extensions:**
-  - [ ] If you created custom extensions, migrate them to the plugin system (see [Plugin Guide](./plugins.md))
-- [ ] **Testing:**
-  - [ ] Run your test suite to catch any missed migrations
-  - [ ] Verify all provider method calls work with `account.provider.xyz()`
-  - [ ] Test plugin functionality (StarknetId, BrotherId)
+`PaymasterRpcOptions.default` was renamed to `mute`. It silences the informational message emitted
+when a `PaymasterRpc` falls back to its default node URL.
 
-## RPC Namespace Renames (v9 → v10)
+**❌ v9:**
+
+```typescript
+const myPaymaster = new PaymasterRpc({ default: true });
+```
+
+**✅ v10:**
+
+```typescript
+const myPaymaster = new PaymasterRpc({ mute: true });
+```
+
+Note that `RpcProviderOptions.default` was removed entirely (it only served the deleted
+`defaultProvider` singleton) and has no replacement.
+
+## Breaking Change 11: felt252 Range Validation
+
+### What Changed
+
+`CairoFelt()` now validates that the value fits in the felt252 range `[0, P)` and throws otherwise.
+In v9, an out-of-range value was silently converted and sent to the network.
+
+```typescript
+// v9: accepted silently
+// v10: throws `Value ... is out of felt252 range [0, ...)`
+CairoFelt(2n ** 252n);
+```
+
+In addition, `CairoFelt252.toApiRequest()` now returns the **decimal** string representation instead
+of the hexadecimal one, which aligns it with the rest of the compiled calldata:
+
+```typescript
+new CairoFelt252(1000n).toApiRequest(); // v9: ['0x3e8'] → v10: ['1000']
+```
+
+### Impact
+
+**Low** for normal use: `CallData.compile()` and contract calls behave the same, since the network
+receives equivalent values. It only affects code that compares compiled calldata to hard-coded
+strings, or that relied on out-of-range values not throwing.
+
+## Breaking Change 12: RPC Namespace Renames
 
 Two public exports were renamed to track the new default RPC spec version. These only affect advanced usage (raw RPC spec types and direct channel imports).
 
@@ -699,6 +701,144 @@ import { RPC0102 } from 'starknet'; // spec 0.10.2 (legacy)
 :::note
 Standard usage via `RpcProvider`, `Account`, and high-level methods is unaffected by these renames.
 :::
+
+## Other Minor Changes
+
+- `getBlock()` called without argument is now typed `Promise<Block>` instead of
+  `Promise<PreConfirmedBlock>`. The runtime behavior is unchanged — it returns the block designated
+  by the provider `blockIdentifier` option — but code that accessed pre-confirmed-only fields on the
+  result no longer type-checks. Use `getBlock('pre_confirmed')` for the pre-confirmed block.
+- `pako` is no longer a dependency (replaced by the native Compression Streams API), alongside the
+  removal of `ts-mixer`.
+
+## Migration Checklist
+
+When upgrading from v9 to v10:
+
+- [ ] Update `starknet` package to v10.x
+- [ ] **Account Composition:**
+  - [ ] Find all `account.xyz()` calls where `xyz` is a provider method
+  - [ ] Replace with `account.provider.xyz()`
+  - [ ] Verify account-specific methods (`execute`, `signMessage`, etc.) still work directly
+- [ ] **Plugin System:**
+  - [ ] Update plugin imports: `StarknetId` → `StarknetIdImpl` (if importing directly)
+  - [ ] Update plugin imports: `BrotherId` → `BrotherIdImpl` (if importing directly)
+  - [ ] Update import paths: `starknet/provider/extensions/` → package root (`'starknet'`)
+  - [ ] Use `starknetIdPlugin()` for the plugin factory, not `starknetId()`
+  - [ ] Test that plugin methods still work: `getStarkName()`, `getAddressFromStarkName()`, etc.
+  - [ ] If using `plugins: false`, verify this is intentional (disables StarknetId/BrotherId/fastExecute)
+- [ ] **fastExecute:**
+  - [ ] Rename the types: `fastExecuteResponse` → `FastExecuteResponse`, `fastWaitForTransactionOptions` → `FastWaitForTransactionOptions`
+  - [ ] If you disabled the default plugins, add `fastExecute()` back to keep `account.fastExecute()` and `provider.fastWaitForTransaction()`
+- [ ] **Compression Functions:**
+  - [ ] Search for `compressProgram()` calls and add `await`
+  - [ ] Search for `decompressProgram()` calls and add `await`
+  - [ ] Search for `parseContract()`, `createSierraContractClass()` and `contractClassResponseToLegacyCompiledContract()` calls and add `await`
+  - [ ] Make calling functions `async` if they weren't already
+- [ ] **Provider Changes:**
+  - [ ] Review any code using `provider.fetch()` with `.then()` chains
+  - [ ] Verify error handling still works correctly
+- [ ] **Storage Queries:**
+  - [ ] Find all `getStorageAt()` calls
+  - [ ] Update usage from `BigInt(result)` to `BigInt(result.value)`
+  - [ ] Rename the imported type `Storage` → `StorageResponse`
+  - [ ] Optionally use `result.last_update_block` if you need metadata
+- [ ] **Paymaster:**
+  - [ ] Rename the `default` option to `mute` in `new PaymasterRpc({ ... })`
+- [ ] **Cairo Types:**
+  - [ ] Check that no felt252 value you build is outside `[0, P)` — it now throws instead of being silently converted
+  - [ ] If you compare compiled calldata to hard-coded strings, note that `CairoFelt252.toApiRequest()` returns decimal, not hex
+- [ ] **SimulateTransaction Response:**
+  - [ ] Find all `getSimulateTransaction()` calls
+  - [ ] Replace direct array access (e.g., `result[0]`, `result.map()`) with `result.simulated_transactions[0]`, `result.simulated_transactions.map()`
+  - [ ] Optionally use `result.initial_reads` if using `returnInitialReads` option
+- [ ] **Dependencies:**
+  - [ ] Remove any references to `ts-mixer` if you were using it
+  - [ ] If you depended on `ts-mixer` or `pako` transitively, add them to your `package.json`
+- [ ] **Custom Extensions:**
+  - [ ] If you created custom extensions, migrate them to the plugin system (see [Plugin Guide](./plugins.md))
+- [ ] **Testing:**
+  - [ ] Run your test suite to catch any missed migrations
+  - [ ] Verify all provider method calls work with `account.provider.xyz()`
+  - [ ] Test plugin functionality (StarknetId, BrotherId)
+
+## New in v10: Transaction `proof` and `proofFacts` Fields
+
+v9 had no transaction proof at all. v10 adds two optional fields to the v3 transaction details,
+following RPC 0.10.1+: `proof` and `proofFacts`. Nothing to migrate — this section only describes
+how to use them.
+
+The `proof` field is typed as a `string`: a base64 encoding of big-endian packed `u32` values.
+Use `stark.encodeProof()` to build it from a number array:
+
+```typescript
+import { stark } from 'starknet';
+
+// Step 1: encode the array to base64
+const proofBase64 = stark.encodeProof([1, 2, 3, 4]);
+// result = "AQAAAAIAAAADAAAABAAAAA=="
+
+// Step 2: pass the encoded string
+await account.execute(calls, {
+  proof: proofBase64, // must be a base64 string
+});
+```
+
+The same option is accepted by the other Account methods:
+
+```typescript
+await account.estimateInvokeFee(calls, { proof: proofBase64 });
+await account.simulateTransaction(invocations, { proof: proofBase64 });
+```
+
+Decode it back if needed:
+
+```typescript
+const proofArray = stark.decodeProof(proofBase64);
+```
+
+### The `proofFacts` Field
+
+`proofFacts` is an optional companion to `proof`. When present, it changes the v3 transaction hash computation (the Poseidon of all proof facts is folded into the hash).
+
+```typescript
+// proofFacts is optional — pass only when your SNIP-36 off-chain computation
+// produces facts that must be committed on-chain
+await account.execute(calls, {
+  proof: proofBase64, // base64-encoded proof (see above)
+  proofFacts: [fact1, fact2], // BigNumberish[] — omit if unused
+});
+```
+
+:::note
+Both fields are optional: code that never sets them behaves exactly as before. Set them only when
+your use case requires SNIP-36 fact commitment — see the [Proofs (SNIP-36) guide](./account/proofs.md).
+:::
+
+## What Else Is New in v10
+
+None of the following requires any migration work, but they are worth knowing about once you are on
+v10:
+
+- **RPC 0.10.3 support.** Two channels ship side by side, `RPC0102` (spec 0.10.2) and `RPC0103`
+  (spec 0.10.3, the default). `RpcProvider.create()` picks the right one from the node.
+- **Runtime plugin installation** with `provider.use(plugin)`, fully typed — see the
+  [Plugin System Guide](./plugins.md).
+- **`contract.compile(method, args)`** returns the compiled `Calldata` alone, without the
+  `Invocation` wrapper produced by `populate()`.
+- **`account.getSignedTransaction()` / `provider.invokeSignedTx()`** to split signing and
+  broadcasting into two steps.
+- **`WalletAccountV6`** and the `walletV6` namespace: wallet-standard connection
+  (`standardConnect()`), STRK20 privacy methods (`strk20Balances`, `strk20PrepareInvoke`,
+  `strk20InvokeTransaction`, `strk20SubaccountCommitment`) and sub-accounts — see the
+  [WalletAccount guide](./account/walletAccount.md).
+- **Initial storage reads:** pass `returnInitialReads: true` to `getSimulateTransaction()` or
+  `getBlockTransactionsTraces()` to get an `initial_reads` field back, and
+  `getTransaction(txHash, { includeProofFacts: true })` to get the proof facts of a transaction.
+- **WebSocket subscriptions:** `fromAddress` now accepts an array of addresses, transaction
+  subscriptions accept `tags`, and reconnection accepts a `stableConnectionThreshold` option — see
+  the [WebSocket guide](./websocket_channel.md).
+- **`walletAccount.onChange()`** now returns an unsubscribe function.
 
 ## Need Help?
 


### PR DESCRIPTION
## Motivation and Resolution

The v9 → v10 migration guide had drifted from the actual library: it was written around
v10.0.x while the current line is v10.6.x, and several of its statements no longer matched
(or never matched) the code.

I audited `git diff v9.4.2..HEAD` over `src/` — public exports, method signatures, option
types, dependencies — and reworked the guide accordingly.

**Breaking changes that were missing:**

- `fastExecute()` / `fastWaitForTransaction()` moved from native `Account` / `RpcProvider`
  methods to the `fastExecute` plugin, with the types renamed
  (`fastExecuteResponse` → `FastExecuteResponse`,
  `fastWaitForTransactionOptions` → `FastWaitForTransactionOptions`).
- `PaymasterRpcOptions.default` renamed to `mute`.
- felt252 range validation is now enforced by `CairoFelt()`, and
  `CairoFelt252.toApiRequest()` returns decimal instead of hexadecimal.
- Response type `Storage` renamed to `StorageResponse`.
- `parseContract()`, `createSierraContractClass()` and
  `contractClassResponseToLegacyCompiledContract()` became async, alongside the already
  documented `compressProgram()` / `decompressProgram()`.
- `getBlock()` with no argument is now typed `Promise<Block>` instead of
  `Promise<PreConfirmedBlock>`; `pako` was dropped as a dependency.

**Factual errors that were fixed:**

- Every `new Account(...)` example used the positional form
  `new Account(provider, address, privateKey)`, which has not existed since v9 — the
  constructor takes a single `AccountOptions` object.
- "Breaking Change 9: Transaction proof Field Type" claimed the `proof` field changed from
  `number[]` to a base64 `string`. v9 has no transaction proof at all
  (`git grep proof v9.4.2 -- src/` only matches merkle utilities and proof-of-personhood),
  so this is a v10 addition, not a migration step. The section is reclassified as a new
  feature and the "⚠️ REQUIRED CHANGE" markers are removed from the summary table and the
  checklist.
- The plugin section pointed to `import { starknetId } from 'starknet/plugins/starknet-id'`.
  That path cannot resolve: `package.json` exposes only the `"."` entry point and ships
  `files: ["dist"]`. It now documents `starknetIdPlugin` from the package root.
- `stark.encodeProof([1, 2, 3, 4])` was documented as returning
  `"AQAAAAIAAAADAAAABAAAAAUAAAAv"`; the actual value is `"AQAAAAIAAAADAAAABAAAAA=="`.
- The `getStorageAt()` and `proof` sections labelled their "before" column `v10.0.0` /
  `v10.0.1+`. Both changes shipped in v10.0.0, so the columns are now `v9` / `v10`.

The same wrong base64 string lived in the `encodeProof` / `decodeProof` JSDoc examples for
`[1, 2, 3, 4, 5]`. It is not merely cosmetic: the documented value has 21 bytes, so pasting
it into `decodeProof()` throws `byte length of Uint32Array should be a multiple of 4`. Both
JSDoc blocks now use `"AQAAAAIAAAADAAAABAAAAAUAAAA="`.

The guide also gains a closing "What Else Is New in v10" section covering RPC 0.10.3,
`provider.use()`, `Contract.compile()`, `getSignedTransaction()` / `invokeSignedTx()`,
`WalletAccountV6` and STRK20, `returnInitialReads`, and the WebSocket subscription options.

Sections are reordered so that all breaking changes come first, then the checklist, then the
additions.

### RPC version (if applicable)

Not applicable — documentation only. The guide now describes the `RPCSPEC0103` / `RPC0102` /
`RPC0103` namespaces as they exist on `develop`.

## Usage related changes

- The migration guide is complete and accurate for the whole v9 → v10.6.x range; the examples
  it contains now compile and run as written.
- The `encodeProof` and `decodeProof` API docs no longer show a base64 value that throws when
  passed back to `decodeProof()`.

## Development related changes

- No runtime code is touched: the only change under `src/` is a two-line JSDoc correction.
- No test change is required — the fixed values are documentation examples, and the behavior
  they describe is already covered.
- Both files pass `npx prettier --check`.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] All tests are passing
