### PR TITLE
fix(channel): reject SNIP-36 fields on RPC 0.9

### DIFF
--- a/__tests__/proof.test.ts
+++ b/__tests__/proof.test.ts
@@ -56,8 +56,9 @@ describeIfTestnet('Proof in transaction', () => {
     });
   });
 
-  // SNIP-36 `proof` and `proofFacts` only exist in the RPC 0.10 spec. The 0.9 channel
-  // silently drops them, so the contract would read empty proof facts and panic.
+  // SNIP-36 `proof` and `proofFacts` only exist in the RPC 0.10 spec. On a 0.9 node the
+  // channel rejects them upfront (SYSTEM_MESSAGES.snip36RequiresRPC010), so these tests
+  // could only observe the SDK guard, never the contract behavior they target.
   describeIfRpc010('proof attached to the transaction', () => {
     test('tx with wrong calldata', async () => {
       const myCall3 = { ...myCall2, calldata: [message.user_id, 0] }; // 0 for is_whitelisted instead of 1

--- a/__tests__/rpcChannel09.test.ts
+++ b/__tests__/rpcChannel09.test.ts
@@ -1,4 +1,4 @@
-import { LibraryError, RPC09, RpcError } from '../src';
+import { constants, LibraryError, RPC09, RpcError } from '../src';
 import {
   createBlockForDevnet,
   createTestProvider,
@@ -278,5 +278,57 @@ describe('UNIT TEST: RPC 0.9.0 Channel waitForTransaction', () => {
       transactionReceiptSpy.mockRestore();
       jest.useRealTimers();
     }
+  });
+});
+
+// No node needed: `buildTransaction` is a pure payload builder, so this suite runs
+// on every RPC version of the CI matrix.
+describe('UNIT TEST: RPC 0.9.0 Channel - SNIP-36 guard', () => {
+  const channel09 = new RPC09.RpcChannel({ nodeUrl: 'http://dummy-node.invalid/rpc' });
+
+  const invocation = {
+    type: 'INVOKE' as const,
+    contractAddress: '0x123',
+    calldata: ['0x1'],
+    signature: [],
+    nonce: '0x1',
+    version: '0x3',
+    resourceBounds: {
+      l1_gas: { max_amount: 1000n, max_price_per_unit: 100n },
+      l2_gas: { max_amount: 2000n, max_price_per_unit: 200n },
+      l1_data_gas: { max_amount: 500n, max_price_per_unit: 50n },
+    },
+    tip: 0n,
+    paymasterData: [],
+    accountDeploymentData: [],
+    nonceDataAvailabilityMode: 'L1' as const,
+    feeDataAvailabilityMode: 'L1' as const,
+  };
+
+  // RPC 0.9 has no `proof_facts` field, but the transaction hash commits to it
+  // anyway. Building the payload silently would produce an invalid signature.
+  test('buildTransaction rejects an INVOKE carrying proofFacts', async () => {
+    await expect(
+      channel09.buildTransaction({ ...invocation, proofFacts: ['0xabc', '0xdef'] })
+    ).rejects.toThrow(constants.SYSTEM_MESSAGES.snip36RequiresRPC010);
+  });
+
+  test('buildTransaction rejects an INVOKE carrying a proof', async () => {
+    await expect(channel09.buildTransaction({ ...invocation, proof: 'AAECAw==' })).rejects.toThrow(
+      constants.SYSTEM_MESSAGES.snip36RequiresRPC010
+    );
+  });
+
+  test('buildTransaction accepts an empty proofFacts array', async () => {
+    const result = await channel09.buildTransaction({ ...invocation, proofFacts: [] });
+
+    expect(result).not.toHaveProperty('proof_facts');
+  });
+
+  test('buildTransaction accepts an INVOKE without any SNIP-36 field', async () => {
+    const result = await channel09.buildTransaction(invocation);
+
+    expect(result).not.toHaveProperty('proof_facts');
+    expect(result).not.toHaveProperty('proof');
   });
 });

--- a/src/channel/rpc_0_9_0.ts
+++ b/src/channel/rpc_0_9_0.ts
@@ -708,6 +708,14 @@ export class RpcChannel {
       SYSTEM_MESSAGES.SWOldV3
     );
 
+    // SNIP-36 fields only exist in the RPC 0.10.1+ payload, but the transaction hash
+    // commits to `proofFacts` whatever the RPC version. Dropping them silently here
+    // would broadcast a transaction whose signature can never be verified.
+    assert(
+      !invocation.proofFacts?.length && !invocation.proof,
+      SYSTEM_MESSAGES.snip36RequiresRPC010
+    );
+
     const details = {
       signature: signatureToHexArray(invocation.signature),
       nonce: toHex(invocation.nonce),

--- a/src/global/constants.ts
+++ b/src/global/constants.ts
@@ -242,6 +242,8 @@ export const SYSTEM_MESSAGES = {
   txEvictedFromMempool: 'Transaction TTL, evicted from the mempool, try to increase the tip',
   consensusFailed: 'Consensus failed to finalize the block proposal',
   txFailsBlockBuildingValidation: 'Transaction fails block building validation',
+  snip36RequiresRPC010:
+    'SNIP-36 `proof` and `proofFacts` are not supported by RPC 0.9, connect to a RPC 0.10.1+ node!',
 };
 
 export const SN_VERSION_IMPLEMENTING_BLAKE_FOR_COMPILED_CLASS = '0.14.1' as const;


### PR DESCRIPTION
## Motivation and Resolution

The SNIP-36 fields `proof` and `proofFacts` only exist in the RPC 0.10.1+ spec. The
RPC 0.9 channel used to drop them silently, which is worse than it looks: the
transaction hash commits to `proofFacts` regardless of the channel version
(`calculateInvokeTransactionHash` adds `poseidonHashMany(proofFacts)` in
`src/utils/hash/transactionHash/v3.ts`). So on a 0.9 node the SDK signed a hash
including `proof_facts_hash` and then broadcast a payload without `proof_facts` —
the node recomputed a different hash and the signature could never verify.

The user-visible symptom gave no hint of the real cause. Running
`__tests__/proof.test.ts` against a 0.9 node failed with RPC error 41
(`TRANSACTION_EXECUTION_ERROR`) raised from `starknet_estimateFee`, whose revert
reason was `ProofFacts deser failed` — a Cairo assertion from the target contract
reading an empty `tx_info.proof_facts`. Nothing pointed to the RPC version.

`buildTransaction` in `src/channel/rpc_0_9_0.ts` now rejects any invocation carrying
`proof` or a non-empty `proofFacts`, with a new `SYSTEM_MESSAGES.snip36RequiresRPC010`
message naming the actual requirement. It is the single choke point of every path
(`execute`, `estimateInvokeFee`, `simulateTransaction`, `invoke`,
`getSignedTransaction`, and direct `provider.channel` usage), so one guard covers
them all. Since `execute()` estimates fees first, the error surfaces before anything
is broadcast.

An empty `proofFacts: []` is still accepted: the existing code tests `.length > 0`
and the transaction hash does not include it either.

### RPC version (if applicable)

RPC 0.9 only. The RPC 0.10 path is unchanged — `proof` and `proofFacts` keep flowing
through `src/channel/rpc_0_10_2.ts`.

## Usage related changes

- Passing `{ proof, proofFacts }` to `account.execute()` (or any other invoke path)
  while connected to an RPC 0.9 node now throws
  `SNIP-36 \`proof\` and \`proofFacts\` are not supported by RPC 0.9, connect to a RPC 0.10.1+ node!`
  instead of sending a transaction whose signature can never be verified.
- No change for RPC 0.10.1+ users, nor for anyone not using SNIP-36.

## Development related changes

- Added a node-less `UNIT TEST: RPC 0.9.0 Channel - SNIP-36 guard` suite in
  `__tests__/rpcChannel09.test.ts`. It sits outside `describeIfRpc09` on purpose:
  `buildTransaction` only assembles a payload, so the guard is verified on every RPC
  version of the CI matrix rather than on the `v0_9` jobs alone. It covers both
  rejection cases (`proofFacts`, `proof`) and both accepted cases (empty array,
  field absent).
- Updated the comment on the `describeIfRpc010` guard in `__tests__/proof.test.ts`:
  it described the old silent-drop behavior, which no longer exists.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing (Devnet rpc 0.9 & rpc 0.10)
