### PR TITLE
fix(ws): guard malformed frames and honour request id 0

### DIFF
--- a/__tests__/WebSocketChannel.reconnect.test.ts
+++ b/__tests__/WebSocketChannel.reconnect.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-classes-per-file */
 import { WebSocketChannel, config } from '../src';
 
 /**
@@ -206,5 +207,110 @@ describe('Unit Test: WebSocketChannel auto-reconnection', () => {
     expect(internal.requestQueue.length).toBe(1);
 
     channel.disconnect();
+  });
+
+  /**
+   * Mock that keeps its own listener registry and invokes listeners directly, so an
+   * exception escaping a listener propagates out of `emitMessage()` and can be asserted
+   * on synchronously. (A real WebSocket dispatches through `EventTarget`, which turns the
+   * same escape into a process-level `uncaughtException` — unobservable from the caller,
+   * which is exactly what made the original crash impossible to intercept.)
+   */
+  const makeMessageMock = () => {
+    let current: any = null;
+    class MockWS {
+      static OPEN = 1;
+
+      public readyState = 1;
+
+      public onopen: ((ev: Event) => void) | null = null;
+
+      public onclose: ((ev: Event) => void) | null = null;
+
+      public onerror: ((ev: Event) => void) | null = null;
+
+      private listeners: Record<string, ((ev: any) => void)[]> = {};
+
+      constructor(_url: string) {
+        current = this;
+      }
+
+      public addEventListener(type: string, listener: (ev: any) => void) {
+        (this.listeners[type] ??= []).push(listener);
+      }
+
+      public removeEventListener(type: string, listener: (ev: any) => void) {
+        this.listeners[type] = (this.listeners[type] ?? []).filter((l) => l !== listener);
+      }
+
+      public send() {}
+
+      public close() {
+        this.readyState = 3;
+      }
+
+      /** Invokes every registered message listener directly, in registration order. */
+      public emitMessage(data: unknown) {
+        [...(this.listeners.message ?? [])].forEach((l) => l({ data } as MessageEvent));
+      }
+    }
+    return {
+      MockWS,
+      get current() {
+        return current as InstanceType<typeof MockWS>;
+      },
+    };
+  };
+
+  test('a non-JSON frame does not escape the message listener; the request still times out', async () => {
+    // Regression: `sendReceive`'s message listener parsed the frame with an unguarded
+    // `JSON.parse`. A gateway pushing a plain-text body over the open socket made it throw
+    // from inside the WebSocket event dispatch — not the promise chain — so no caller-side
+    // try/catch could intercept it and the host process died on an uncaughtException.
+    const mock = makeMessageMock();
+    config.set('websocket', mock.MockWS as any);
+
+    const channel = new WebSocketChannel({
+      nodeUrl: 'wss://mock',
+      autoReconnect: false,
+      requestTimeout: 200,
+    });
+
+    const pending = channel.sendReceive('starknet_chainId');
+    // Swallow the expected rejection now so the timeout below is never an unhandled one.
+    const settled = pending.catch((e) => e);
+
+    // The exact body an Alchemy gateway sends when its upstream node is unreachable.
+    expect(() =>
+      mock.current.emitMessage(
+        'upstream connect error or disconnect/reset before headers. retried and the latest reset reason: connection timeout'
+      )
+    ).not.toThrow();
+
+    // The malformed frame carries no request id, so it cannot settle the promise:
+    // `requestTimeout` does.
+    const error = await settled;
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain('timed out after 200ms');
+  });
+
+  test('a valid response arriving after a malformed frame still resolves the request', async () => {
+    const mock = makeMessageMock();
+    config.set('websocket', mock.MockWS as any);
+
+    const channel = new WebSocketChannel({
+      nodeUrl: 'wss://mock',
+      autoReconnect: false,
+      requestTimeout: 2000,
+    });
+
+    const pending = channel.sendReceive('starknet_chainId');
+
+    mock.current.emitMessage('not json at all');
+    mock.current.emitMessage(
+      JSON.stringify({ jsonrpc: '2.0', id: 0, result: '0x534e5f5345504f4c4941' })
+    );
+
+    await expect(pending).resolves.toBe('0x534e5f5345504f4c4941');
   });
 });

--- a/__tests__/WebSocketChannel.test.ts
+++ b/__tests__/WebSocketChannel.test.ts
@@ -595,3 +595,53 @@ describe('Unit Test: Subscription Class', () => {
     expect(mockChannel.removeSubscription).toHaveBeenCalledWith('sub_123');
   });
 });
+
+describe('Unit Test: WebSocketChannel request id resolution', () => {
+  let webSocketChannel: WebSocketChannel;
+  let sendSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    // No real connection needed: the socket is stubbed out entirely.
+    webSocketChannel = new WebSocketChannel({
+      nodeUrl: 'ws://dummy-url',
+      autoReconnect: false,
+    });
+    jest.spyOn(webSocketChannel, 'isConnected').mockReturnValue(true);
+    sendSpy = jest.spyOn(webSocketChannel.websocket, 'send').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    webSocketChannel.disconnect();
+  });
+
+  test('should honour an explicitly provided id of 0', () => {
+    // Regression: `idResolver` tested the id for truthiness, so an explicit 0 — a valid
+    // JSON-RPC id — was discarded in favour of an auto-generated one. Callers of the
+    // low-level `send()` match responses to requests by id themselves, so the id on the
+    // wire must be the one they asked for.
+    //
+    // The managed counter starts at 0, so its first value is 0 too: one unmanaged send
+    // is issued first to advance it past 0, otherwise both the correct and the buggy
+    // behaviour would produce the same id and the assertion would prove nothing.
+    expect(webSocketChannel.send('starknet_chainId')).toBe(0);
+    sendSpy.mockClear();
+
+    const usedId = webSocketChannel.send('starknet_chainId', undefined, 0);
+
+    expect(usedId).toBe(0);
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    const payload = sendSpy.mock.calls[0][0] as string;
+    expect(JSON.parse(payload).id).toBe(0);
+    expect(payload).toContain('"id":0');
+  });
+
+  test('should honour other explicitly provided ids and leave the internal counter untouched', () => {
+    expect(webSocketChannel.send('starknet_chainId', undefined, 7)).toBe(7);
+    expect(JSON.parse(sendSpy.mock.calls[0][0] as string).id).toBe(7);
+
+    // The managed counter is independent of user-set ids, and starts at 0.
+    expect(webSocketChannel.send('starknet_chainId')).toBe(0);
+    expect(webSocketChannel.send('starknet_chainId')).toBe(1);
+  });
+});

--- a/src/channel/ws/ws_0_10.ts
+++ b/src/channel/ws/ws_0_10.ts
@@ -263,8 +263,9 @@ export class WebSocketChannel {
   }
 
   private idResolver(id?: number) {
-    // An unmanaged, user-set ID.
-    if (id) return id;
+    // An unmanaged, user-set ID. Tested against `undefined` rather than for
+    // truthiness: 0 is a valid JSON-RPC id and must be honoured as passed.
+    if (id !== undefined) return id;
     // Managed ID, intentionally returned old and then incremented.
     // eslint-disable-next-line no-plusplus
     return this.sendId++;
@@ -335,7 +336,22 @@ export class WebSocketChannel {
           logger.warn('WebSocket received non-string message data:', event.data);
           return;
         }
-        const message: JRPC.ResponseBody = JSON.parse(event.data);
+        let message: JRPC.ResponseBody;
+        try {
+          message = JSON.parse(event.data);
+        } catch (error) {
+          // Skip the malformed frame instead of rejecting the pending promise: a non-JSON
+          // frame (e.g. a gateway pushing a plain-text error body over the open socket)
+          // carries no request id, so it cannot be attributed to a specific in-flight
+          // request. Letting the parse throw here would escape the WebSocket event dispatch
+          // rather than the promise chain, so no caller-side try/catch could intercept it
+          // and it would kill the process as an uncaught exception. The pending request is
+          // still ended by `requestTimeout`.
+          logger.error(
+            `WebSocketChannel: Error parsing incoming message: ${event.data}, Error: ${error}`
+          );
+          return;
+        }
         if (message.id === sendId) {
           clearTimeout(timeoutId);
           this.websocket.removeEventListener('message', messageHandler);


### PR DESCRIPTION
## Motivation and Resolution

Two independent robustness bugs in the WebSocket channel (`src/channel/ws/ws_0_10.ts`).

**1. A non-JSON frame killed the host process.** The message listener created inside
`sendReceive()` parsed incoming frames with an unguarded `JSON.parse(event.data)`.
Reproduced against Alchemy: when their upstream node is unreachable, the gateway pushes a
plain-text body over the open socket — `"upstream connect error or disconnect/reset before
headers. retried and the latest reset reason: connection timeout"` — which yields:

```
SyntaxError: Unexpected token 'u', "upstream c"... is not valid JSON
    at JSON.parse (<anonymous>)
    at WebSocket.messageHandler (src/channel/ws/ws_0_10.ts:338:49)
    at WebSocket.dispatchEvent (node:internal/event_target:778:26)
```

The important part is the failure mode: the throw happens inside a listener invoked by the
WebSocket event dispatch, **not** inside the promise chain. It therefore does not reject the
`sendReceive()` promise, so no `try { await channel.sendReceive(...) } catch {}` on the caller
side can intercept it — it escapes as an `uncaughtException` and terminates the process.
`onMessageProxy()` already guarded the exact same parse; only this second call site was missing it.

Resolution: the parse is now wrapped in the same `try/catch` — log via `logger.error` with the
offending payload, then skip the frame. The pending promise is deliberately **not** rejected
from there: a non-JSON frame carries no request id, so it cannot be attributed to a specific
in-flight request. The existing `requestTimeout` already ends the request.

**2. `idResolver` rejected a valid request id of `0`.** It tested `if (id)` for truthiness, so
`channel.send('starknet_chainId', undefined, 0)` silently got an auto-generated id instead of
the one requested, and the frame put on the wire did not carry the caller's id. This matters
because `send()` is the low-level API documented for callers that match responses to requests
themselves — `www/docs/guides/websocket_channel.md` tells them to read `channel.on('message', …)`
and find the message carrying the same id. Now tested against `undefined`.

The internal counter `sendId` still starts at 0 and the `message.id === sendId` comparison in
`sendReceive` remains strict; neither was changed.

No public API change.

### RPC version (if applicable)

Not applicable — both are transport-level fixes in the WebSocket channel, independent of the
RPC spec version.

## Usage related changes

- A malformed (non-JSON) WebSocket frame no longer crashes the host process. It is logged via
  `logger.error` and skipped; any request in flight is ended by `requestTimeout` as before.
- `WebSocketChannel.send(method, params, 0)` now honours the explicitly passed id `0` and emits
  `"id":0` on the wire, instead of substituting an auto-generated id.

## Development related changes

- `__tests__/WebSocketChannel.reconnect.test.ts`: two regression tests reusing the existing mock
  WebSocket harness injected via `config.set('websocket', ...)` — no live node needed. A dedicated
  mock invokes its message listeners directly so an escaping exception is observable synchronously
  (a real `EventTarget` converts it into a process-level `uncaughtException`, which is exactly what
  made the original crash impossible to intercept). One test asserts the Alchemy plain-text body
  does not escape the listener and that the pending `sendReceive()` still settles on its timeout;
  the other asserts a valid response arriving after a malformed frame still resolves normally.
- `__tests__/WebSocketChannel.test.ts`: new `Unit Test: WebSocketChannel request id resolution`
  block, following the existing `nodeUrl: 'ws://dummy-url'` unit-test pattern with a stubbed socket.
  Note the test issues one unmanaged `send()` first to advance the counter past 0 — the managed
  counter also starts at 0, so without that step both the correct and the buggy behaviour would
  produce the same id and the assertion would prove nothing.
- Both tests were verified to fail without their respective fix (`Expected: 0 / Received: 1` for
  the id bug; the original `SyntaxError` at `ws_0_10.ts:338:49` for the parse bug).

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
