### PR TITLE
fix(ws): reject queued requests instead of hanging

### DIFF
--- a/__tests__/WebSocketChannel.reconnect.test.ts
+++ b/__tests__/WebSocketChannel.reconnect.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-classes-per-file */
-import { WebSocketChannel, config } from '../src';
+import { WebSocketChannel, WebSocketNotConnectedError, config } from '../src';
 
 /**
  * Unit tests for the auto-reconnection state machine, using a mock WebSocket
@@ -293,6 +293,121 @@ describe('Unit Test: WebSocketChannel auto-reconnection', () => {
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toContain('timed out after 200ms');
   });
+
+  /**
+   * Mock whose first socket connects, and whose every later socket fails to establish.
+   * Reproduces a node that stops accepting connections: the channel reconnects, exhausts
+   * its retries, and gives up.
+   */
+  const makeUnreachableAfterFirstMock = () => {
+    let created = 0;
+    let current: any = null;
+    class MockWS extends EventTarget {
+      static OPEN = 1;
+
+      public readyState = 0;
+
+      public onopen: ((ev: Event) => void) | null = null;
+
+      public onclose: ((ev: Event) => void) | null = null;
+
+      public onerror: ((ev: Event) => void) | null = null;
+
+      constructor(_url: string) {
+        super();
+        created += 1;
+        current = this;
+        const isFirst = created === 1;
+        setTimeout(() => {
+          if (this.readyState === 3) return;
+          if (isFirst) {
+            this.readyState = 1;
+            const ev = new Event('open');
+            this.onopen?.(ev);
+            this.dispatchEvent(ev);
+          } else {
+            // Every reconnection attempt is refused.
+            this.readyState = 3;
+            const ev = new Event('error');
+            this.onerror?.(ev);
+            this.dispatchEvent(ev);
+          }
+        }, 5);
+      }
+
+      public send() {}
+
+      public close() {
+        this.emitClose();
+      }
+
+      public emitClose() {
+        if (this.readyState === 3) return;
+        this.readyState = 3;
+        const ev = new Event('close');
+        this.onclose?.(ev);
+        this.dispatchEvent(ev);
+      }
+    }
+    return {
+      MockWS,
+      get current() {
+        return current as InstanceType<typeof MockWS>;
+      },
+    };
+  };
+
+  test('rejects queued requests once reconnection gives up', async () => {
+    // Regression: a request queued during a reconnection carries no timeout of its own —
+    // `requestTimeout` is only armed once the request is actually sent. When reconnection
+    // gave up, the queue was left untouched, so the promise stayed pending forever and no
+    // caller-side timeout could rescue it. In CI this turned a few seconds of gateway
+    // unavailability into a test hanging for the full 5-minute Jest timeout.
+    const mock = makeUnreachableAfterFirstMock();
+    config.set('websocket', mock.MockWS as any);
+
+    const channel = new WebSocketChannel({
+      nodeUrl: 'wss://mock',
+      reconnectOptions: { retries: 2, delay: 20, exponential: false },
+    });
+    await channel.waitForConnection();
+
+    // Drop the connection: the channel enters its reconnection cycle, which can never succeed.
+    mock.current.emitClose();
+    const pending = channel.sendReceive('starknet_chainId');
+
+    await expect(pending).rejects.toThrow(WebSocketNotConnectedError);
+    await expect(pending).rejects.toThrow(/never sent: reconnection gave up after 2 attempts/);
+
+    channel.disconnect();
+    // Explicit per-test timeout: the whole point of this test is that the promise settles.
+    // Without it, a regression would hang for the suite-wide 5 minutes instead of failing.
+  }, 10000);
+
+  test('rejects queued requests when the user disconnects mid-reconnection', async () => {
+    const mock = makeUnreachableAfterFirstMock();
+    config.set('websocket', mock.MockWS as any);
+
+    const channel = new WebSocketChannel({
+      nodeUrl: 'wss://mock',
+      // Long enough that the retries are still pending when disconnect() is called.
+      reconnectOptions: { retries: 10, delay: 5000, exponential: false },
+    });
+    await channel.waitForConnection();
+
+    mock.current.emitClose();
+    const pending = channel.sendReceive('starknet_chainId');
+
+    channel.disconnect();
+
+    await expect(pending).rejects.toThrow(WebSocketNotConnectedError);
+    await expect(pending).rejects.toThrow(/never sent: the connection was closed by the user/);
+
+    // The reconnection flag must be cleared too, otherwise every later request would queue
+    // for a reconnection that is no longer coming.
+    expect((channel as unknown as { isReconnecting: boolean }).isReconnecting).toBe(false);
+    // See the note on the previous test.
+  }, 10000);
 
   test('a valid response arriving after a malformed frame still resolves the request', async () => {
     const mock = makeMessageMock();

--- a/__tests__/WebSocketChannel.test.ts
+++ b/__tests__/WebSocketChannel.test.ts
@@ -373,11 +373,18 @@ describeIfWs('E2E WebSocket Tests', () => {
           simulateConnectionDrop(webSocketChannel);
 
           // 2. Immediately try to send a request. It should be queued.
-          webSocketChannel.sendReceive('starknet_chainId').then((result) => {
-            // 3. This assertion runs after reconnection, proving the queue was processed.
-            expect(result).toBe(StarknetChainId.SN_SEPOLIA);
-            done(); // 4. Test is done when the queued request has been successfully processed.
-          });
+          webSocketChannel
+            .sendReceive('starknet_chainId')
+            .then((result) => {
+              // 3. This assertion runs after reconnection, proving the queue was processed.
+              expect(result).toBe(StarknetChainId.SN_SEPOLIA);
+              done(); // 4. Test is done when the queued request has been successfully processed.
+            })
+            // Report the failure instead of leaving `done()` uncalled. A queued request
+            // carries no timeout of its own, and reconnection giving up does not settle it,
+            // so anything other than the happy path would otherwise hang until Jest's
+            // global 5-minute timeout with no indication of what went wrong.
+            .catch(done);
         }
       });
     });
@@ -398,17 +405,22 @@ describeIfWs('E2E WebSocket Tests', () => {
           simulateConnectionDrop(webSocketChannel);
 
           // 2. Immediately try to subscribe. The request should be queued.
-          webSocketChannel.subscribeNewHeads().then((sub) => {
-            // 3. This should only execute after reconnection.
-            expect(sub).toBeInstanceOf(Subscription);
-            expect(webSocketChannel.isConnected()).toBe(true);
+          webSocketChannel
+            .subscribeNewHeads()
+            .then((sub) => {
+              // 3. This should only execute after reconnection.
+              expect(sub).toBeInstanceOf(Subscription);
+              expect(webSocketChannel.isConnected()).toBe(true);
 
-            // 4. To prove it's a real subscription, wait for one event.
-            sub.on((data) => {
-              expect(data).toBeDefined();
-              done();
-            });
-          });
+              // 4. To prove it's a real subscription, wait for one event.
+              sub.on((data) => {
+                expect(data).toBeDefined();
+                done();
+              });
+            })
+            // See the note on the previous test: report the failure rather than leaving
+            // `done()` uncalled and hanging until the global timeout.
+            .catch(done);
         }
       });
     });
@@ -433,11 +445,18 @@ describeIfWs('E2E WebSocket Tests', () => {
       webSocketChannel.on('open', async () => {
         connectionCount += 1;
         if (connectionCount === 1) {
-          // First connection: set up the subscription
-          const sub = await webSocketChannel.subscribeNewHeads();
-          sub.on(eventHandler);
-          // Now, simulate a drop
-          simulateConnectionDrop(webSocketChannel);
+          try {
+            // First connection: set up the subscription
+            const sub = await webSocketChannel.subscribeNewHeads();
+            sub.on(eventHandler);
+            // Now, simulate a drop
+            simulateConnectionDrop(webSocketChannel);
+          } catch (error) {
+            // This handler is `async`, so a rejection here would surface as an unobserved
+            // promise rejection and leave `done()` uncalled — the test would hang until the
+            // global timeout instead of reporting the cause.
+            done(error);
+          }
         }
         // On the second 'open' event (connectionCount === 2), the test will implicitly
         // be waiting for the eventHandler to be called, which will resolve the test.

--- a/src/channel/ws/ws_0_10.ts
+++ b/src/channel/ws/ws_0_10.ts
@@ -447,6 +447,10 @@ export class WebSocketChannel {
     // Set the flag before closing so the resulting `close` event does not trigger
     // an automatic reconnection.
     this.userInitiatedClose = true;
+    // Clear the reconnection state too: left set, it would make every later sendReceive()
+    // queue for a reconnection that is no longer coming.
+    this.isReconnecting = false;
+    this._rejectRequestQueue('the connection was closed by the user');
     this.websocket.close(code, reason);
   }
 
@@ -537,6 +541,26 @@ export class WebSocketChannel {
     });
   }
 
+  /**
+   * Reject every request still waiting in the queue.
+   *
+   * A queued request carries no timeout of its own: the `requestTimeout` timer is only
+   * armed once the request is actually put on the wire. So once the channel reaches a state
+   * where the queue can never be flushed — reconnection gave up, or the user closed the
+   * connection — the queued promises would stay pending forever, and no caller-side timeout
+   * could rescue them. Settling them here is the only way out.
+   */
+  private _rejectRequestQueue(reason: string): void {
+    if (this.requestQueue.length === 0) return;
+    // Detach before iterating, for the same reason as _processRequestQueue.
+    const pending = this.requestQueue;
+    this.requestQueue = [];
+    logger.info(`WebSocket: Rejecting ${pending.length} queued request(s). Reason: ${reason}.`);
+    pending.forEach(({ method, reject }) => {
+      reject(new WebSocketNotConnectedError(`Request ${method} was never sent: ${reason}`));
+    });
+  }
+
   private async _restoreSubscriptions(): Promise<void> {
     const oldSubscriptions = Array.from(this.activeSubscriptions.values());
     this.activeSubscriptions.clear();
@@ -590,6 +614,9 @@ export class WebSocketChannel {
       if (this.reconnectAttempts >= this.reconnectOptions.retries) {
         logger.error('WebSocket: Maximum reconnection retries reached. Giving up.');
         this.isReconnecting = false;
+        this._rejectRequestQueue(
+          `reconnection gave up after ${this.reconnectOptions.retries} attempts`
+        );
         return;
       }
 

--- a/www/docs/guides/websocket_channel.md
+++ b/www/docs/guides/websocket_channel.md
@@ -255,6 +255,11 @@ methods.
 A call made while the connection is down is queued and sent once the socket is back. If no answer
 comes within `requestTimeout` (60 s by default), the promise rejects with a `TimeoutError`.
 
+A queued call is never left pending: if the connection never comes back — reconnection gave up, or
+you called `disconnect()` — the promise rejects with a `WebSocketNotConnectedError` instead. Note
+that `requestTimeout` only starts once the request is actually sent, so it is the reconnection
+settings below, not `requestTimeout`, that bound how long a queued call can wait.
+
 :::tip
 `channel.send()` sends a request and returns its id at once, without waiting for the answer. You then
 have to read the incoming messages yourself (`channel.on('message', …)`) and find the one carrying
@@ -287,6 +292,10 @@ const channel = new WebSocketChannel({
 `stableConnectionThreshold` is how long a new connection must stay open before it is considered
 stable and the retry counter is reset. It prevents a node that accepts then immediately drops the
 connection from being retried forever.
+
+Once `retries` attempts have failed, the channel gives up and stops reconnecting on its own. Any
+request still queued at that point is rejected with a `WebSocketNotConnectedError`. Call
+`reconnect()` to start over.
 
 ## Error handling
 


### PR DESCRIPTION
## Motivation and Resolution

Two problems with a single root cause: a `sendReceive()` promise that could never settle.

**The library bug.** When the connection is down, `sendReceive()` queues the request and returns a
promise. That queued promise carries **no timeout of its own** — `requestTimeout` is only armed
once a request is actually put on the wire. Meanwhile the give-up path of the reconnection loop
("Maximum reconnection retries reached") reset `isReconnecting` and returned, leaving
`requestQueue` untouched. A caller awaiting a request issued during an outage that never recovered
therefore waited forever: no caller-side timeout could rescue it, and nothing was reported after
the give-up log line.

`disconnect()` had the same hole plus a second one: it never cleared `isReconnecting`, so after a
disconnect during a reconnection cycle every later `sendReceive()` queued for a reconnection that
was no longer coming.

Resolution: a private `_rejectRequestQueue(reason)` settles every queued request with a
`WebSocketNotConnectedError` naming the method and the reason. It is called from both dead ends —
the give-up path and `disconnect()` — and `disconnect()` now clears `isReconnecting`.

**How it surfaced.** A "[Manual] Test Testnet" run failed on Juno v0.10 only: `should queue
sendReceive requests when reconnecting and process them after` hung for the full 300 s Jest
timeout waiting for `done()`. A re-run went green and every other node/version combination passed
first try, so the trigger was transient — gateway throttling or a TCP/TLS blip during the retry
window. But a few seconds of node unavailability should not cost five minutes of CI and a red job
with no diagnostic. Three tests in that suite chained `.then()` without `.catch()`, so any
rejection *or* non-settlement left `done()` uncalled; they now report the failure instead.

### RPC version (if applicable)

Not applicable — a transport-level fix in the WebSocket channel, independent of the RPC spec
version.

## Usage related changes

- A `sendReceive()` call queued while the connection is down now always settles. If reconnection
  gives up after `retries` attempts, or if `disconnect()` is called first, the promise rejects with
  a `WebSocketNotConnectedError` instead of staying pending forever.
- `disconnect()` now clears the internal reconnecting state, so a `sendReceive()` issued afterwards
  no longer queues for a reconnection that will never happen.
- WebSocket guide updated: which error ends a queued call, and the fact that `requestTimeout` does
  **not** bound how long a queued request waits — the reconnection settings do. The guide
  previously promised a `TimeoutError` the code did not deliver in this case.

## Development related changes

- Two regression tests in `__tests__/WebSocketChannel.reconnect.test.ts`, on the existing
  mock-WebSocket harness (`config.set('websocket', ...)`, no live node): reconnection giving up,
  and `disconnect()` mid-reconnection. Both verified to fail without the fix.
- Those two tests carry an explicit per-test timeout. `jest.setTimeout(5 * 60 * 1000)` in
  `__tests__/config/jest.setup.ts` overrides the `--testTimeout` CLI flag, so without one a
  regression on a "the promise must settle" property hangs for five minutes instead of failing —
  precisely the failure mode this PR removes.
- Three E2E tests in `__tests__/WebSocketChannel.test.ts` now report their failure (`.catch(done)`,
  and a `try/catch` for the `async` open handler) instead of waiting for the global timeout. This
  also covers a silent case: an `expect()` failing inside a `.then()` used to hang the suite rather
  than report an assertion error.
- Teardown fix in the same suite: the Auto-Reconnection `afterEach` no longer fails the test that
  just ran when the socket emits an `error` while closing. `waitForDisconnection()` rejects on that
  event, and some nodes emit it on close — which made the whole block unrunnable against a local
  devnet. This is cleanup, already bounded by a 3 s race.
- With that, the suite becomes partially runnable without a public gateway:
  `TEST_WS_URL=ws://127.0.0.1:5050/ws` against starknet-devnet passes 3 of the 5
  Auto-Reconnection tests, including the one that flaked in CI. The two remaining ones wait
  passively for a `newHeads` event; devnet only mints blocks on demand, so making them run means
  having them cause the event they await — a separate change, not attempted here.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
