### PR TITLE
fix(ws): settle in-flight requests when the connection drops

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -86,12 +86,12 @@ jobs:
         name: run tests
         run: |
           args=()
-          # --forceExit: the WebSocket suite exercises auto-reconnection against a
-          # live gateway that (on Pathfinder) never completes the closing handshake
-          # of a still-subscribed socket, leaving an open handle that would keep
-          # Jest from exiting after the run completes. The `--` lets npm forward the
-          # flag through to Jest.
-          [[ "${{ inputs.protocol }}" == "WS" ]] && args+=( '--forceExit' '__tests__/WebSocket' )
+          # The WS run is restricted to the WebSocket suites; the `--` lets npm forward the
+          # path filter through to Jest. It used to also need --forceExit, because dropping a
+          # still-subscribed socket left a connection the gateway would not release and Jest
+          # never exited; the suite now unsubscribes that socket itself, so a run that hangs
+          # here is a real leak and must not be papered over.
+          [[ "${{ inputs.protocol }}" == "WS" ]] && args+=( '__tests__/WebSocket' )
           npm run test:coverage -- "${args[@]}"
         env:
           TEST_RPC_URL: ${{ steps.node-url.outputs.rpc-url }}

--- a/__tests__/WebSocketChannel.reconnect.test.ts
+++ b/__tests__/WebSocketChannel.reconnect.test.ts
@@ -12,6 +12,20 @@ describe('Unit Test: WebSocketChannel auto-reconnection', () => {
       setTimeout(resolve, ms);
     });
 
+  /**
+   * Report how `promise` settled, or `'pending'` if it had not within `ms`. The losing timer
+   * is cleared either way: an un-cleared one outlives the test and keeps Jest from exiting.
+   */
+  const outcomeWithin = (promise: Promise<unknown>, ms: number): Promise<string> => {
+    let timer: NodeJS.Timeout | undefined;
+    return Promise.race([
+      promise.then(() => 'resolved').catch(() => 'rejected'),
+      new Promise<string>((resolve) => {
+        timer = setTimeout(() => resolve('pending'), ms);
+      }),
+    ]).finally(() => clearTimeout(timer));
+  };
+
   let originalLogLevel: ReturnType<typeof config.get>;
 
   beforeAll(() => {
@@ -27,10 +41,21 @@ describe('Unit Test: WebSocketChannel auto-reconnection', () => {
     config.set('logLevel', originalLogLevel as any);
   });
 
-  /** Counts how many sockets get created, to detect a runaway reconnection loop. */
-  const makeMock = (behavior: 'flap' | 'stable') => {
+  /**
+   * A mock WebSocket whose behaviour on connect is chosen per test:
+   * - `stable` — connects and stays open.
+   * - `flap` — connects, then drops 10ms later, as a rate-limiting gateway does.
+   * - `error-after-first` — the first socket connects, every later one fails with `error`.
+   * - `refuse-after-first` — same, but the refusal is a bare `close` with no `error` first.
+   *
+   * `created` counts the sockets opened, which is how a runaway reconnection loop is detected.
+   */
+  type SocketBehavior = 'stable' | 'flap' | 'error-after-first' | 'refuse-after-first';
+
+  const makeMock = (behavior: SocketBehavior) => {
     let created = 0;
     let current: any = null;
+
     class MockWS extends EventTarget {
       static CONNECTING = 0;
 
@@ -40,7 +65,7 @@ describe('Unit Test: WebSocketChannel auto-reconnection', () => {
 
       static CLOSED = 3;
 
-      public readyState = 0;
+      public readyState = MockWS.CONNECTING;
 
       public onopen: ((ev: Event) => void) | null = null;
 
@@ -56,17 +81,22 @@ describe('Unit Test: WebSocketChannel auto-reconnection', () => {
         super();
         created += 1;
         current = this;
+        const isFirst = created === 1;
         this.timers.push(
           setTimeout(() => {
-            if (this.readyState === 3) return; // closed before it could open
-            this.readyState = 1;
-            const ev = new Event('open');
-            this.onopen?.(ev);
-            this.dispatchEvent(ev);
+            if (this.readyState === MockWS.CLOSED) return; // closed before it could open
+            if (!isFirst && behavior === 'error-after-first') {
+              this.readyState = MockWS.CLOSED;
+              this.emit('error');
+              return;
+            }
+            if (!isFirst && behavior === 'refuse-after-first') {
+              this.emitClose();
+              return;
+            }
+            this.readyState = MockWS.OPEN;
+            this.emit('open');
             if (behavior === 'flap') {
-              // Accept the connection then immediately drop it, as a rate-limiting
-              // gateway does. This used to reset the retry counter every cycle and
-              // reconnect forever.
               this.timers.push(setTimeout(() => this.emitClose(), 10));
             }
           }, 5)
@@ -82,13 +112,20 @@ describe('Unit Test: WebSocketChannel auto-reconnection', () => {
       public emitClose() {
         this.timers.forEach(clearTimeout);
         this.timers = [];
-        if (this.readyState === 3) return;
-        this.readyState = 3;
-        const ev = new Event('close');
-        this.onclose?.(ev);
+        if (this.readyState === MockWS.CLOSED) return;
+        this.readyState = MockWS.CLOSED;
+        this.emit('close');
+      }
+
+      /** Fires both the `on*` property and the listeners, as a real WebSocket does. */
+      private emit(type: 'open' | 'close' | 'error') {
+        const ev = new Event(type);
+        const handlers = { open: this.onopen, close: this.onclose, error: this.onerror };
+        handlers[type]?.(ev);
         this.dispatchEvent(ev);
       }
     }
+
     return {
       MockWS,
       get created() {
@@ -117,8 +154,9 @@ describe('Unit Test: WebSocketChannel auto-reconnection', () => {
 
     await wait(3000);
 
-    // 1 initial + at most `retries` reconnection attempts. Without the fix this
-    // grows without bound (hundreds within a few seconds).
+    // 1 initial socket + at most `retries` reconnection attempts. A gateway that accepts then
+    // immediately drops must not reset the retry counter on every cycle: that reconnects
+    // forever, opening hundreds of sockets within a few seconds.
     expect(mock.created).toBeLessThanOrEqual(6);
 
     channel.disconnect();
@@ -140,8 +178,8 @@ describe('Unit Test: WebSocketChannel auto-reconnection', () => {
     await channel.waitForConnection();
     expect(channel.isConnected()).toBe(true);
 
-    // Five drops, more than `retries`, each followed by a stable period. Each must
-    // reconnect: the counter resets after the connection stays open past the threshold.
+    // Five drops, more than `retries`, each followed by a stable period. Each must reconnect:
+    // the counter resets after the connection stays open past the threshold.
     for (let k = 0; k < 5; k += 1) {
       mock.current.emitClose();
       // eslint-disable-next-line no-await-in-loop
@@ -153,12 +191,10 @@ describe('Unit Test: WebSocketChannel auto-reconnection', () => {
   });
 
   test('draining the request queue while still disconnected does not loop forever', () => {
-    // Regression: `_processRequestQueue` used to iterate `this.requestQueue` directly.
-    // When the socket dropped again mid-reconnect, `sendReceive` re-queued each request
-    // synchronously into that same array, so the loop never emptied it — an unbounded
-    // synchronous loop that allocated until the process OOM-crashed. Here the channel is
-    // held in the "reconnecting" state so every `sendReceive` re-queues, and a push
-    // counter proves the loop stays bounded instead of running away.
+    // The channel is held in the "reconnecting" state, so every `sendReceive` re-queues. A
+    // `_processRequestQueue` iterating its own array in place would therefore never empty it —
+    // an unbounded synchronous loop allocating a Promise per turn until the process OOMs. The
+    // push counter proves the loop stays bounded.
     const mock = makeMock('stable');
     config.set('websocket', mock.MockWS as any);
 
@@ -199,9 +235,8 @@ describe('Unit Test: WebSocketChannel auto-reconnection', () => {
     // eslint-disable-next-line no-underscore-dangle
     internal._processRequestQueue();
 
-    // With the fix the seeded request is re-queued at most once (into the fresh, detached
-    // queue), so the instrumented array sees no re-push. Without it, `requeueCount` blows
-    // past the cap.
+    // The seeded request is re-queued at most once, into the fresh detached queue, so the
+    // instrumented array sees no re-push.
     expect(requeueCount).toBeLessThanOrEqual(1);
     // The request is deferred to the next reconnection cycle, not dropped.
     expect(internal.requestQueue.length).toBe(1);
@@ -263,10 +298,9 @@ describe('Unit Test: WebSocketChannel auto-reconnection', () => {
   };
 
   test('a non-JSON frame does not escape the message listener; the request still times out', async () => {
-    // Regression: `sendReceive`'s message listener parsed the frame with an unguarded
-    // `JSON.parse`. A gateway pushing a plain-text body over the open socket made it throw
-    // from inside the WebSocket event dispatch — not the promise chain — so no caller-side
-    // try/catch could intercept it and the host process died on an uncaughtException.
+    // An unguarded `JSON.parse` on the frame throws from inside the WebSocket event dispatch
+    // rather than the promise chain, so no caller-side try/catch can intercept it and the host
+    // process dies on an uncaughtException.
     const mock = makeMessageMock();
     config.set('websocket', mock.MockWS as any);
 
@@ -292,78 +326,38 @@ describe('Unit Test: WebSocketChannel auto-reconnection', () => {
     const error = await settled;
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toContain('timed out after 200ms');
+
+    channel.disconnect();
   });
 
-  /**
-   * Mock whose first socket connects, and whose every later socket fails to establish.
-   * Reproduces a node that stops accepting connections: the channel reconnects, exhausts
-   * its retries, and gives up.
-   */
-  const makeUnreachableAfterFirstMock = () => {
-    let created = 0;
-    let current: any = null;
-    class MockWS extends EventTarget {
-      static OPEN = 1;
+  test('a valid response arriving after a malformed frame still resolves the request', async () => {
+    const mock = makeMessageMock();
+    config.set('websocket', mock.MockWS as any);
 
-      public readyState = 0;
+    const channel = new WebSocketChannel({
+      nodeUrl: 'wss://mock',
+      autoReconnect: false,
+      requestTimeout: 2000,
+    });
 
-      public onopen: ((ev: Event) => void) | null = null;
+    const pending = channel.sendReceive('starknet_chainId');
 
-      public onclose: ((ev: Event) => void) | null = null;
+    mock.current.emitMessage('not json at all');
+    mock.current.emitMessage(
+      JSON.stringify({ jsonrpc: '2.0', id: 0, result: '0x534e5f5345504f4c4941' })
+    );
 
-      public onerror: ((ev: Event) => void) | null = null;
+    await expect(pending).resolves.toBe('0x534e5f5345504f4c4941');
 
-      constructor(_url: string) {
-        super();
-        created += 1;
-        current = this;
-        const isFirst = created === 1;
-        setTimeout(() => {
-          if (this.readyState === 3) return;
-          if (isFirst) {
-            this.readyState = 1;
-            const ev = new Event('open');
-            this.onopen?.(ev);
-            this.dispatchEvent(ev);
-          } else {
-            // Every reconnection attempt is refused.
-            this.readyState = 3;
-            const ev = new Event('error');
-            this.onerror?.(ev);
-            this.dispatchEvent(ev);
-          }
-        }, 5);
-      }
-
-      public send() {}
-
-      public close() {
-        this.emitClose();
-      }
-
-      public emitClose() {
-        if (this.readyState === 3) return;
-        this.readyState = 3;
-        const ev = new Event('close');
-        this.onclose?.(ev);
-        this.dispatchEvent(ev);
-      }
-    }
-    return {
-      MockWS,
-      get current() {
-        return current as InstanceType<typeof MockWS>;
-      },
-    };
-  };
+    channel.disconnect();
+  });
 
   test('rejects queued requests once reconnection gives up', async () => {
-    // Regression: a request queued during a reconnection carries no timeout of its own —
-    // `requestTimeout` is only armed once the request is actually sent. When reconnection
-    // gave up, the queue was left untouched, so the promise stayed pending forever and no
-    // caller-side timeout could rescue it. In CI this turned a few seconds of gateway
-    // unavailability into a test hanging for the full 5-minute Jest timeout.
-    const mock = makeUnreachableAfterFirstMock();
+    // A queued request carries no timeout of its own — `requestTimeout` is armed only once it
+    // is actually sent. If the give-up path left the queue untouched, the promise would stay
+    // pending forever and no caller-side timeout could rescue it: in CI a few seconds of
+    // gateway unavailability became a test hanging for the full 5-minute Jest timeout.
+    const mock = makeMock('error-after-first');
     config.set('websocket', mock.MockWS as any);
 
     const channel = new WebSocketChannel({
@@ -372,7 +366,7 @@ describe('Unit Test: WebSocketChannel auto-reconnection', () => {
     });
     await channel.waitForConnection();
 
-    // Drop the connection: the channel enters its reconnection cycle, which can never succeed.
+    // Drop the connection: the channel enters a reconnection cycle that can never succeed.
     mock.current.emitClose();
     const pending = channel.sendReceive('starknet_chainId');
 
@@ -380,12 +374,12 @@ describe('Unit Test: WebSocketChannel auto-reconnection', () => {
     await expect(pending).rejects.toThrow(/never sent: reconnection gave up after 2 attempts/);
 
     channel.disconnect();
-    // Explicit per-test timeout: the whole point of this test is that the promise settles.
-    // Without it, a regression would hang for the suite-wide 5 minutes instead of failing.
+    // Explicit per-test timeout: the whole point is that the promise settles. Without it, a
+    // regression would hang for the suite-wide 5 minutes instead of failing.
   }, 10000);
 
   test('rejects queued requests when the user disconnects mid-reconnection', async () => {
-    const mock = makeUnreachableAfterFirstMock();
+    const mock = makeMock('error-after-first');
     config.set('websocket', mock.MockWS as any);
 
     const channel = new WebSocketChannel({
@@ -409,23 +403,76 @@ describe('Unit Test: WebSocketChannel auto-reconnection', () => {
     // See the note on the previous test.
   }, 10000);
 
-  test('a valid response arriving after a malformed frame still resolves the request', async () => {
-    const mock = makeMessageMock();
+  test('settles an in-flight request when the user disconnects', async () => {
+    // A request already on the wire lives entirely inside the `sendReceive` closure — a timer
+    // plus two socket listeners, unreachable from outside. A clean close emits `close`, not
+    // `error`, so neither handler fires and the timer runs its full 60s default, holding the
+    // Node event loop open and leaving the caller's promise pending all that time.
+    const mock = makeMock('stable');
+    config.set('websocket', mock.MockWS as any);
+
+    const channel = new WebSocketChannel({ nodeUrl: 'wss://mock' });
+    await channel.waitForConnection();
+
+    // Goes on the wire rather than into the queue: the socket is open. The mock's `send()`
+    // is a no-op, so no reply will ever come back.
+    const pending = channel.sendReceive('starknet_chainId');
+
+    channel.disconnect();
+
+    await expect(outcomeWithin(pending, 1000)).resolves.toBe('rejected');
+  });
+
+  test('settles an in-flight request when the connection drops', async () => {
+    // Same trapped request, but on a drop the channel did not own: `disconnect()` is never
+    // called, so the close path itself has to settle it.
+    const mock = makeMock('stable');
     config.set('websocket', mock.MockWS as any);
 
     const channel = new WebSocketChannel({
       nodeUrl: 'wss://mock',
-      autoReconnect: false,
-      requestTimeout: 2000,
+      reconnectOptions: { retries: 2, delay: 20, exponential: false },
     });
+    await channel.waitForConnection();
 
     const pending = channel.sendReceive('starknet_chainId');
+    mock.current.emitClose();
 
-    mock.current.emitMessage('not json at all');
-    mock.current.emitMessage(
-      JSON.stringify({ jsonrpc: '2.0', id: 0, result: '0x534e5f5345504f4c4941' })
-    );
+    await expect(outcomeWithin(pending, 1000)).resolves.toBe('rejected');
+    await expect(pending).rejects.toThrow(WebSocketNotConnectedError);
 
-    await expect(pending).resolves.toBe('0x534e5f5345504f4c4941');
+    channel.disconnect();
+  });
+
+  test('settles a queued request when a reconnection attempt is refused without an error event', async () => {
+    // A rate-limiting gateway refuses a new connection by closing the socket, without
+    // necessarily emitting `error` first. A `tryReconnect` arming its retry only from `onerror`
+    // never reschedules; the `close` that did arrive returns early from `_startReconnect`
+    // because `isReconnecting` is still true. No further attempt is made, `reconnectAttempts`
+    // never reaches `retries`, and the give-up branch that rejects the queue stays unreachable.
+    const mock = makeMock('refuse-after-first');
+    config.set('websocket', mock.MockWS as any);
+
+    const channel = new WebSocketChannel({
+      nodeUrl: 'wss://mock',
+      reconnectOptions: {
+        retries: 3,
+        delay: 20,
+        exponential: false,
+        stableConnectionThreshold: 100,
+      },
+    });
+    await channel.waitForConnection();
+
+    // Drop the live connection. Every reconnection attempt from here on is refused.
+    mock.current.emitClose();
+
+    // Queued, because the channel is now in the reconnecting state.
+    const pending = channel.sendReceive('starknet_chainId');
+
+    // Three retries of 20ms plus the give-up rejection land well inside 2s.
+    await expect(outcomeWithin(pending, 2000)).resolves.toBe('rejected');
+
+    channel.disconnect();
   });
 });

--- a/__tests__/WebSocketChannel.test.ts
+++ b/__tests__/WebSocketChannel.test.ts
@@ -1,5 +1,11 @@
 /* eslint-disable no-underscore-dangle */
-import { Provider, Subscription, SubscriptionNewHeadsEvent, WebSocketChannel } from '../src';
+import {
+  Provider,
+  Subscription,
+  SubscriptionNewHeadsEvent,
+  WebSocketChannel,
+  config,
+} from '../src';
 import { logger } from '../src/global/logger';
 import { StarknetChainId } from '../src/global/constants';
 import { getTestAccount, getTestProvider, STRKtokenAddress, TEST_WS_URL } from './config';
@@ -10,19 +16,43 @@ const NODE_URL = TEST_WS_URL!;
 /**
  * Simulate an abnormal network drop to exercise auto-reconnection.
  *
- * A real network drop surfaces to the client as a `close` event (RFC 6455 code
- * 1006) without a closing handshake; the channel reacts to that event exactly as
- * it does here and starts reconnecting. We cannot use `socket.close()` for this:
- * some Starknet gateways (Pathfinder) never complete the closing handshake while a
- * subscription is active, so the `close` event would never fire and reconnection
- * would never start. Dispatching the event directly is both reliable and a closer
- * match to a real drop. The now-orphaned socket is closed best-effort to avoid
- * leaking the connection.
+ * A real drop surfaces as a `close` event (RFC 6455 code 1006) without a closing handshake,
+ * and the channel reacts to that event exactly as it does here. `socket.close()` cannot be
+ * used instead: some gateways (Pathfinder) never complete the closing handshake while a
+ * subscription is active, so the `close` event would never fire and reconnection would
+ * never start.
+ *
+ * The socket the channel abandons is then released here, because nothing else will — the
+ * channel has already moved on to its replacement, so no teardown can reach it. Closing it is
+ * not enough on its own: a graceful close that the gateway will not answer while a subscription
+ * is still bound leaves the connection open for the rest of the run, and a single one of those
+ * keeps the Node event loop alive after the suite has passed. Note that `--detectOpenHandles`
+ * does not attribute that handle to anything, so it is no help in tracking it down.
  */
 const simulateConnectionDrop = (channel: WebSocketChannel) => {
   const socket = channel.websocket;
+  // Subscription ids still bound to this socket, captured before the drop: restoring them on
+  // the replacement socket clears the map.
+  const subscriptionIds = Array.from(
+    ((channel as any).activeSubscriptions as Map<string, unknown>).keys()
+  );
+
   socket.dispatchEvent(new Event('close'));
+
   try {
+    // Unsubscribe before closing, so the gateway has no reason to hold the connection. The
+    // replies land on a socket whose listeners `onCloseProxy` has already detached, so they
+    // are simply ignored.
+    subscriptionIds.forEach((id, i) => {
+      socket.send(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1_000_000 + i,
+          method: 'starknet_unsubscribe',
+          params: { subscription_id: id },
+        })
+      );
+    });
     socket.close();
   } catch {
     // ignore: the socket may already be closing/closed
@@ -32,15 +62,14 @@ const simulateConnectionDrop = (channel: WebSocketChannel) => {
 /**
  * Open a WebSocket channel, retrying on connection errors.
  *
- * The shared gateways rate-limit new connections per IP. Opening several in quick
- * succession (as this suite does) gets a fresh connection rejected with an error
- * event, which `waitForConnection()` surfaces as a rejection. The limit replenishes
- * within ~1s, so retry with a spaced backoff.
+ * The shared gateways rate-limit new connections per IP, and a whole suite run opens around
+ * twenty; once the limit trips it can take tens of seconds to replenish, and the rejected
+ * connection surfaces through `waitForConnection()`. Hence five attempts with exponential
+ * backoff, 1/2/4/8s — ~15s of waiting, while a connection that succeeds first try never sleeps.
  *
- * `autoReconnect` is forced off: this helper owns the retry loop, and letting the
- * channel also auto-reconnect in the background on a failed attempt would spawn
- * overlapping reconnection loops (each retrying for tens of seconds) that pile up
- * under rate-limiting.
+ * `autoReconnect` is forced off: this helper owns the retry loop, and letting the channel also
+ * reconnect in the background on a failed attempt would spawn overlapping reconnection loops
+ * (each retrying for tens of seconds) that pile up under rate-limiting.
  */
 const openChannel = async (
   options: ConstructorParameters<typeof WebSocketChannel>[0]
@@ -57,13 +86,86 @@ const openChannel = async (
     } catch (error) {
       lastError = error;
       channel.disconnect();
+      // Last attempt: the loop is about to throw, so sleeping only delays the report.
+      if (attempt === retries - 1) break;
       // eslint-disable-next-line no-await-in-loop
       await new Promise((resolve) => {
-        setTimeout(resolve, backoffMs);
+        setTimeout(resolve, backoffMs * 2 ** attempt);
       });
     }
   }
   throw lastError;
+};
+
+/**
+ * Resolve when `promise` settles or `ms` elapses, whichever comes first.
+ *
+ * The losing timer is always cleared: an un-cleared one keeps the Node event loop alive past
+ * the end of the run, which is what makes Jest report that it "did not exit".
+ */
+const withTimeout = async (promise: Promise<unknown>, ms: number): Promise<void> => {
+  let timer: NodeJS.Timeout | undefined;
+  await Promise.race([
+    promise,
+    new Promise((resolve) => {
+      timer = setTimeout(resolve, ms);
+    }),
+  ]).finally(() => clearTimeout(timer));
+};
+
+/**
+ * A WebSocket that never touches the network.
+ *
+ * The unit describes at the bottom of this file need no connection and pass
+ * `nodeUrl: 'ws://dummy-url'`, but the channel constructor opens a socket regardless and that
+ * host never resolves — each one then sits in CONNECTING on a DNS lookup that never completes,
+ * keeping the Node event loop alive after the run. A socket stuck before DNS resolution cannot
+ * finish closing either, so the only fix is to never open one.
+ */
+class OfflineWebSocket extends EventTarget {
+  static CONNECTING = 0;
+
+  static OPEN = 1;
+
+  static CLOSING = 2;
+
+  static CLOSED = 3;
+
+  public readyState = OfflineWebSocket.CONNECTING;
+
+  public onopen: ((ev: Event) => void) | null = null;
+
+  public onclose: ((ev: Event) => void) | null = null;
+
+  public onerror: ((ev: Event) => void) | null = null;
+
+  public onmessage: ((ev: Event) => void) | null = null;
+
+  // eslint-disable-next-line @typescript-eslint/no-useless-constructor, no-useless-constructor
+  constructor(_url: string) {
+    super();
+  }
+
+  public send() {}
+
+  public close() {
+    if (this.readyState === OfflineWebSocket.CLOSED) return;
+    this.readyState = OfflineWebSocket.CLOSED;
+    const ev = new Event('close');
+    this.onclose?.(ev);
+    this.dispatchEvent(ev);
+  }
+}
+
+/** Routes every channel built inside the calling describe through `OfflineWebSocket`. */
+const useOfflineSocket = () => {
+  beforeAll(() => {
+    config.set('websocket', OfflineWebSocket as any);
+  });
+
+  afterAll(() => {
+    config.set('websocket', undefined as any);
+  });
 };
 
 describeIfWs('E2E WebSocket Tests', () => {
@@ -287,9 +389,12 @@ describeIfWs('E2E WebSocket Tests', () => {
     });
 
     afterAll(async () => {
-      expect(webSocketChannel.isConnected()).toBe(true);
+      // `beforeAll` can fail to connect at all (per-IP rate limiting), leaving the channel
+      // unassigned. Without this guard teardown throws a TypeError, which Jest reports as
+      // "Test suite failed to run", hiding the connection error that actually caused it.
+      if (!webSocketChannel) return;
       webSocketChannel.disconnect();
-      await webSocketChannel.waitForDisconnection();
+      await webSocketChannel.waitForDisconnection().catch(() => undefined);
     });
 
     test('regular rpc endpoint', async () => {
@@ -303,19 +408,30 @@ describeIfWs('E2E WebSocket Tests', () => {
 
     afterEach(async () => {
       // Ensure the channel is always disconnected after each test to prevent open handles.
-      if (webSocketChannel) {
-        webSocketChannel.disconnect();
-        // Some gateways (Pathfinder) never complete the closing handshake while a
-        // subscription is still active, so waitForDisconnection() could hang here.
-        // Bound the wait: the next test always builds a fresh channel, and the node
-        // reclaims the idle socket on its own.
-        await Promise.race([
-          webSocketChannel.waitForDisconnection(),
-          new Promise((resolve) => {
-            setTimeout(resolve, 3000);
-          }),
-        ]);
-      }
+      if (!webSocketChannel) return;
+
+      // Unsubscribe first: a gateway that will not complete the closing handshake of a
+      // still-subscribed socket leaves it in CLOSING for good, and that handle outlives the
+      // whole run. Several tests here call `done()` from inside a subscription handler, so
+      // nothing else drops them. Best-effort and bounded — teardown must not fail or stall
+      // on a dead socket.
+      const subs: Array<{ isClosed: boolean; unsubscribe: () => Promise<boolean> }> = Array.from(
+        ((webSocketChannel as any).activeSubscriptions as Map<string, any>).values()
+      );
+      await withTimeout(
+        Promise.all(subs.filter((s) => !s.isClosed).map((s) => s.unsubscribe().catch(() => false))),
+        2000
+      );
+
+      webSocketChannel.disconnect();
+      // Those same gateways can leave `waitForDisconnection()` hanging, so bound it: the next
+      // test builds a fresh channel and the node reclaims the idle socket on its own. It also
+      // rejects on the socket's `error` event, which some nodes (devnet among them) emit while
+      // closing — a noisy shutdown must not fail the test that just ran.
+      await withTimeout(
+        webSocketChannel.waitForDisconnection().catch(() => undefined),
+        3000
+      );
     });
 
     test('should automatically reconnect on connection drop', (done) => {
@@ -380,10 +496,9 @@ describeIfWs('E2E WebSocket Tests', () => {
               expect(result).toBe(StarknetChainId.SN_SEPOLIA);
               done(); // 4. Test is done when the queued request has been successfully processed.
             })
-            // Report the failure instead of leaving `done()` uncalled. A queued request
-            // carries no timeout of its own, and reconnection giving up does not settle it,
-            // so anything other than the happy path would otherwise hang until Jest's
-            // global 5-minute timeout with no indication of what went wrong.
+            // Report the failure rather than leave `done()` uncalled: a queued request has no
+            // timeout of its own, so the test would otherwise hang until Jest's global one
+            // with no indication of what went wrong.
             .catch(done);
         }
       });
@@ -418,8 +533,7 @@ describeIfWs('E2E WebSocket Tests', () => {
                 done();
               });
             })
-            // See the note on the previous test: report the failure rather than leaving
-            // `done()` uncalled and hanging until the global timeout.
+            // See the note on the previous test.
             .catch(done);
         }
       });
@@ -452,9 +566,8 @@ describeIfWs('E2E WebSocket Tests', () => {
             // Now, simulate a drop
             simulateConnectionDrop(webSocketChannel);
           } catch (error) {
-            // This handler is `async`, so a rejection here would surface as an unobserved
-            // promise rejection and leave `done()` uncalled — the test would hang until the
-            // global timeout instead of reporting the cause.
+            // This handler is `async`: an unobserved rejection would leave `done()` uncalled
+            // and the test hanging until the global timeout instead of reporting the cause.
             done(error);
           }
         }
@@ -466,6 +579,8 @@ describeIfWs('E2E WebSocket Tests', () => {
 });
 
 describe('Unit Test: WebSocketChannel Buffering', () => {
+  useOfflineSocket();
+
   let webSocketChannel: WebSocketChannel;
   let sub: Subscription;
 
@@ -561,6 +676,8 @@ describe('Unit Test: WebSocketChannel Buffering', () => {
 });
 
 describe('Unit Test: Subscription Class', () => {
+  useOfflineSocket();
+
   let mockChannel: WebSocketChannel;
   let subscription: Subscription;
 
@@ -616,6 +733,8 @@ describe('Unit Test: Subscription Class', () => {
 });
 
 describe('Unit Test: WebSocketChannel request id resolution', () => {
+  useOfflineSocket();
+
   let webSocketChannel: WebSocketChannel;
   let sendSpy: jest.SpyInstance;
 

--- a/src/channel/ws/ws_0_10.ts
+++ b/src/channel/ws/ws_0_10.ts
@@ -216,6 +216,9 @@ export class WebSocketChannel {
     reject: (reason?: any) => void;
   }> = [];
 
+  /** Abort handles for the requests currently on the wire, one per pending `sendReceive`. */
+  private inFlight = new Set<(reason: string) => void>();
+
   private events = new EventEmitter<WebSocketChannelEvents>();
 
   private openListener = (ev: Event) => {
@@ -322,14 +325,30 @@ export class WebSocketChannel {
     }
 
     const sendId = this.send(method, params);
+    // The socket the request actually went out on: a reconnection replaces `this.websocket`,
+    // and the listeners below must be removed from the instance they were added to.
+    const socket = this.websocket;
 
     return new Promise((resolve, reject) => {
-      let timeoutId: NodeJS.Timeout;
-
-      if (!this.websocket || this.websocket.readyState !== WebSocket.OPEN) {
+      if (socket.readyState !== WebSocket.OPEN) {
         reject(new WebSocketNotConnectedError('WebSocket not available or not connected.'));
         return;
       }
+
+      let timeoutId: NodeJS.Timeout;
+
+      /* eslint-disable @typescript-eslint/no-use-before-define --
+         `settle` and the handlers it detaches are mutually recursive; every name it reads is
+         defined by the time it can run. */
+      // Detaches everything this request owns, so no exit path leaves a listener, a timer or
+      // an abort handle behind.
+      const settle = () => {
+        clearTimeout(timeoutId);
+        socket.removeEventListener('message', messageHandler);
+        socket.removeEventListener('error', errorHandler);
+        this.inFlight.delete(abort);
+      };
+      /* eslint-enable @typescript-eslint/no-use-before-define */
 
       const messageHandler = (event: MessageEvent) => {
         if (!isString(event.data)) {
@@ -340,38 +359,27 @@ export class WebSocketChannel {
         try {
           message = JSON.parse(event.data);
         } catch (error) {
-          // Skip the malformed frame instead of rejecting the pending promise: a non-JSON
-          // frame (e.g. a gateway pushing a plain-text error body over the open socket)
-          // carries no request id, so it cannot be attributed to a specific in-flight
-          // request. Letting the parse throw here would escape the WebSocket event dispatch
-          // rather than the promise chain, so no caller-side try/catch could intercept it
-          // and it would kill the process as an uncaught exception. The pending request is
-          // still ended by `requestTimeout`.
+          // Skip the malformed frame instead of rejecting: it carries no request id, so it
+          // cannot be attributed to a pending request. Letting the parse throw would escape
+          // the WebSocket event dispatch rather than the promise chain — no caller-side
+          // try/catch could intercept it, and it would kill the process as an uncaught
+          // exception. The request is still ended by `requestTimeout`.
           logger.error(
             `WebSocketChannel: Error parsing incoming message: ${event.data}, Error: ${error}`
           );
           return;
         }
-        if (message.id === sendId) {
-          clearTimeout(timeoutId);
-          this.websocket.removeEventListener('message', messageHandler);
-          // eslint-disable-next-line @typescript-eslint/no-use-before-define
-          this.websocket.removeEventListener('error', errorHandler);
-
-          if ('result' in message) {
-            resolve(message.result as T);
-          } else {
-            reject(
-              new Error(`Error on ${method} (id: ${sendId}): ${JSON.stringify(message.error)}`)
-            );
-          }
+        if (message.id !== sendId) return;
+        settle();
+        if ('result' in message) {
+          resolve(message.result as T);
+        } else {
+          reject(new Error(`Error on ${method} (id: ${sendId}): ${JSON.stringify(message.error)}`));
         }
       };
 
       const errorHandler = (event: Event) => {
-        clearTimeout(timeoutId);
-        this.websocket.removeEventListener('message', messageHandler);
-        this.websocket.removeEventListener('error', errorHandler);
+        settle();
         reject(
           new Error(
             `WebSocket error during ${method} (id: ${sendId}): ${event.type || 'Unknown error'}`
@@ -379,13 +387,22 @@ export class WebSocketChannel {
         );
       };
 
-      this.websocket.addEventListener('message', messageHandler);
-      this.websocket.addEventListener('error', errorHandler);
+      // The only handle on this request from outside its closure. See `_rejectInFlight`.
+      const abort = (reason: string) => {
+        settle();
+        reject(
+          new WebSocketNotConnectedError(
+            `Request ${method} (id: ${sendId}) went unanswered: ${reason}`
+          )
+        );
+      };
+
+      socket.addEventListener('message', messageHandler);
+      socket.addEventListener('error', errorHandler);
+      this.inFlight.add(abort);
 
       timeoutId = setTimeout(() => {
-        // Clean up listeners
-        this.websocket.removeEventListener('message', messageHandler);
-        this.websocket.removeEventListener('error', errorHandler);
+        settle();
         reject(
           new TimeoutError(
             `Request ${method} (id: ${sendId}) timed out after ${this.requestTimeout}ms`
@@ -451,6 +468,7 @@ export class WebSocketChannel {
     // queue for a reconnection that is no longer coming.
     this.isReconnecting = false;
     this._rejectRequestQueue('the connection was closed by the user');
+    this._rejectInFlight('the connection was closed by the user');
     this.websocket.close(code, reason);
   }
 
@@ -525,14 +543,11 @@ export class WebSocketChannel {
   }
 
   private _processRequestQueue(): void {
-    // Snapshot and detach the queue before draining it. `sendReceive` re-queues a
-    // request synchronously when the connection is not open (e.g. the socket dropped
-    // again mid-reconnect, so `isReconnecting` is true or `isConnected()` is false).
-    // Iterating `this.requestQueue` directly would let those re-queued items be
-    // re-processed in the same pass — an unbounded synchronous loop that allocates a
-    // Promise per turn until the process runs out of memory. Draining a detached
-    // snapshot bounds the loop to the requests present now; re-queued ones land in the
-    // fresh `this.requestQueue` and wait for the next reconnection cycle.
+    // Drain a detached snapshot. `sendReceive` re-queues synchronously when the connection is
+    // not open (the socket dropped again mid-reconnect), so iterating `this.requestQueue` in
+    // place would re-process those items in the same pass — an unbounded synchronous loop
+    // allocating a Promise per turn. Re-queued requests land in the fresh array instead and
+    // wait for the next reconnection cycle.
     const pending = this.requestQueue;
     this.requestQueue = [];
     logger.info(`WebSocket: Processing ${pending.length} queued requests.`);
@@ -559,6 +574,23 @@ export class WebSocketChannel {
     pending.forEach(({ method, reject }) => {
       reject(new WebSocketNotConnectedError(`Request ${method} was never sent: ${reason}`));
     });
+  }
+
+  /**
+   * Settle every request already on the wire.
+   *
+   * The counterpart of `_rejectRequestQueue`, for requests past the queue. Their only other
+   * exit is the `requestTimeout` timer, so without this the caller waits the whole timeout —
+   * 60s by default — for a reply that can no longer arrive, and that pending timer keeps the
+   * Node event loop alive for just as long.
+   */
+  private _rejectInFlight(reason: string): void {
+    if (this.inFlight.size === 0) return;
+    // Snapshot before draining: each abort removes itself from the set as it settles.
+    const pending = Array.from(this.inFlight);
+    this.inFlight.clear();
+    logger.info(`WebSocket: Rejecting ${pending.length} in-flight request(s). Reason: ${reason}.`);
+    pending.forEach((abort) => abort(reason));
   }
 
   private async _restoreSubscriptions(): Promise<void> {
@@ -627,8 +659,31 @@ export class WebSocketChannel {
 
       this.reconnect(); // Attempt to reconnect
 
+      // A failed attempt surfaces as `error`, as `close`, or as both — browsers emit `error`
+      // then `close`, while a gateway refusing the connection outright (rate limiting) may only
+      // close it. Scheduling from `error` alone deadlocks on that last case: the `close` that
+      // does arrive hits the `isReconnecting` guard in `_startReconnect` and returns, so
+      // `reconnectAttempts` never reaches `retries` and even the give-up branch is unreachable.
+      // Schedule from whichever signal comes first, and only once, so the two paths cannot
+      // start parallel reconnection loops.
+      let attemptSettled = false;
+      const scheduleRetry = () => {
+        // `isReconnecting` is cleared both by `disconnect()` and by the give-up branch; the
+        // close that follows either must not arm a further attempt, or a timer outlives
+        // the channel.
+        if (attemptSettled || !this.isReconnecting) return;
+        attemptSettled = true;
+        const delay = this.reconnectOptions.exponential
+          ? this.reconnectOptions.delay * 2 ** (this.reconnectAttempts - 1)
+          : this.reconnectOptions.delay;
+        logger.info(`WebSocket: Reconnect attempt failed. Retrying in ${delay}ms.`);
+        this.reconnectTimeoutId = setTimeout(tryReconnect, delay);
+      };
+
       this.websocket.onopen = async () => {
         logger.info('WebSocket: Reconnection successful.');
+        // A later drop on this socket goes through `onCloseProxy`, not this attempt's retry.
+        attemptSettled = true;
         this.isReconnecting = false;
         // The attempt counter is reset by the openListener's stability timer, not here:
         // a reconnection that drops again before proving stable must keep its count.
@@ -638,13 +693,10 @@ export class WebSocketChannel {
         this.events.emit('open', new Event('open'));
       };
 
-      this.websocket.onerror = () => {
-        const delay = this.reconnectOptions.exponential
-          ? this.reconnectOptions.delay * 2 ** (this.reconnectAttempts - 1)
-          : this.reconnectOptions.delay;
-        logger.info(`WebSocket: Reconnect attempt failed. Retrying in ${delay}ms.`);
-        this.reconnectTimeoutId = setTimeout(tryReconnect, delay);
-      };
+      this.websocket.onerror = scheduleRetry;
+      // Registered as a listener rather than assigned to `onclose`: `waitForDisconnection()`
+      // owns that property, and overwriting it would break a caller awaiting the close.
+      this.websocket.addEventListener('close', scheduleRetry);
     };
 
     tryReconnect();
@@ -655,6 +707,11 @@ export class WebSocketChannel {
     this.websocket.removeEventListener('close', this.closeListener);
     this.websocket.removeEventListener('message', this.messageListener);
     this.websocket.removeEventListener('error', this.errorListener);
+    // Nothing on the wire can still be answered on a closed socket, and a clean close emits no
+    // `error` event, so without this those requests would sit until `requestTimeout`. A no-op
+    // after `disconnect()`, which drains them before closing — the closing handshake itself is
+    // not guaranteed to complete.
+    this._rejectInFlight('the connection was closed');
     this.events.emit('close', ev);
 
     if (!this.userInitiatedClose) {


### PR DESCRIPTION
## Motivation and Resolution

A request already sent over the WebSocket lived entirely inside the `sendReceive` closure: a `requestTimeout` timer plus two socket listeners, none of them reachable from outside. A connection that closes cleanly emits `close`, not `error`, so neither listener fired. The caller's promise stayed pending for a reply that could no longer arrive, and the pending timer kept the Node event loop alive for the full timeout — 60 s by default.

`disconnect()` already rejected the requests still sitting in the queue. This PR extends the same treatment to the requests past the queue, and wires it into the close path so it covers connections the channel loses as well as those the user closes.

The branch also cleans up the two WebSocket test suites, which accumulated near-duplicate mocks and post-mortem commentary while these reconnection bugs were being chased, and removes the `--forceExit` the CI needed for the WebSocket run.

### RPC version (if applicable)

Not applicable — no change to the RPC spec surface.

## Usage related changes

- A pending `sendReceive()` now rejects with `WebSocketNotConnectedError` as soon as the connection closes, instead of hanging until `requestTimeout` for a response that can no longer arrive. This applies both to `disconnect()` and to a connection the channel loses on its own.
- The listeners a request registers are now removed from the socket they were added to, instead of from whichever socket `this.websocket` points at once a reconnection has replaced it.

## Development related changes

- CI: `--forceExit` removed from the WebSocket run. The suite used to leave behind one still-subscribed socket that the gateway would not release, so Jest never exited after a passing run. `simulateConnectionDrop` now unsubscribes the socket the channel abandons before closing it, which removes the gateway's reason to hold it. A run that hangs from now on is a real leak rather than something the flag papers over.
- `__tests__/WebSocketChannel.reconnect.test.ts`: three near-identical WebSocket mock classes merged into a single `makeMock(behavior)` factory covering the stable, flapping, erroring and refusing gateways; the repeated `Promise.race` timeout patterns extracted into helpers.
- Two regression tests added, covering an in-flight request settled on a user disconnect and on a connection drop.
- `sendReceive`'s four duplicated cleanup blocks replaced by a single `settle()` call site, which also cuts the scattered `no-use-before-define` directives down to one scoped pair.
- Comment volume reduced across the three files, with the before/after narratives replaced by the invariant each test or guard actually holds.

Verified against a local Pathfinder node on Sepolia (RPC 0.10.3-rc.0): 32/32 tests pass, and the WebSocket run goes from never exiting to a clean exit in ~36 s with no socket left behind.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
