### PR TITLE
fix(ws): close the subscription lifecycle races

### DIFF
--- a/__tests__/WebSocketChannel.test.ts
+++ b/__tests__/WebSocketChannel.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-underscore-dangle */
+/* eslint-disable no-underscore-dangle, max-classes-per-file */
 import {
   Provider,
   Subscription,
@@ -7,7 +7,6 @@ import {
   config,
 } from '../src';
 import { logger } from '../src/global/logger';
-import { StarknetChainId } from '../src/global/constants';
 import { getTestAccount, getTestProvider, STRKtokenAddress, TEST_WS_URL } from './config';
 
 const describeIfWs = TEST_WS_URL ? describe : describe.skip;
@@ -157,6 +156,63 @@ class OfflineWebSocket extends EventTarget {
   }
 }
 
+/**
+ * A WebSocket driven entirely by the test: it records what the channel sends and delivers
+ * incoming frames on demand, several in one synchronous burst if asked.
+ *
+ * That burst is the point. A gateway flushing a batch dispatches its frames back to back
+ * within a single read, so a frame can be processed *before* the continuation that the
+ * previous frame woke has had a chance to run. No live node reproduces that window on demand.
+ */
+class ScriptedWebSocket extends EventTarget {
+  static CONNECTING = 0;
+
+  static OPEN = 1;
+
+  static CLOSING = 2;
+
+  static CLOSED = 3;
+
+  static current: ScriptedWebSocket;
+
+  public readyState = ScriptedWebSocket.OPEN;
+
+  public onopen: ((ev: Event) => void) | null = null;
+
+  public onclose: ((ev: Event) => void) | null = null;
+
+  public onerror: ((ev: Event) => void) | null = null;
+
+  public onmessage: ((ev: Event) => void) | null = null;
+
+  /** Every frame the channel has sent, already parsed. */
+  public sent: any[] = [];
+
+  constructor(_url: string) {
+    super();
+    ScriptedWebSocket.current = this;
+  }
+
+  public send(data: string) {
+    this.sent.push(JSON.parse(data));
+  }
+
+  public close() {
+    if (this.readyState === ScriptedWebSocket.CLOSED) return;
+    this.readyState = ScriptedWebSocket.CLOSED;
+    const ev = new Event('close');
+    this.onclose?.(ev);
+    this.dispatchEvent(ev);
+  }
+
+  /** Delivers frames back to back, without yielding to the microtask queue in between. */
+  public deliver(...frames: object[]) {
+    frames.forEach((frame) => {
+      this.dispatchEvent(new MessageEvent('message', { data: JSON.stringify(frame) }));
+    });
+  }
+}
+
 /** Routes every channel built inside the calling describe through `OfflineWebSocket`. */
 const useOfflineSocket = () => {
   beforeAll(() => {
@@ -169,6 +225,20 @@ const useOfflineSocket = () => {
 };
 
 describeIfWs('E2E WebSocket Tests', () => {
+  /**
+   * The chain the node under test actually serves.
+   *
+   * Asserting against a hardcoded `SN_SEPOLIA` pinned the whole suite to one network and made
+   * every run on another one fail on the constant rather than on anything real. Reading it from
+   * the RPC provider also makes the assertion stronger: it now checks that the WebSocket channel
+   * and the HTTP channel agree on the chain, instead of checking a literal.
+   */
+  let expectedChainId: string;
+
+  beforeAll(async () => {
+    expectedChainId = await new Provider(getTestProvider()).getChainId();
+  });
+
   describe('websocket specific endpoints', () => {
     // Updated for RPC 0.9: removed subscribePendingTransaction (not available in 0.9)
     // Added subscribeNewTransactionReceipts and subscribeNewTransactions (new in 0.9)
@@ -219,7 +289,7 @@ describeIfWs('E2E WebSocket Tests', () => {
       // To prove the connection is working, make a simple RPC call.
       // This avoids the flakiness of creating and tearing down a real subscription.
       const chainId = await webSocketChannel.sendReceive('starknet_chainId');
-      expect(chainId).toBe(StarknetChainId.SN_SEPOLIA);
+      expect(chainId).toBe(expectedChainId);
     });
 
     test('Test subscribeNewHeads', async () => {
@@ -399,7 +469,7 @@ describeIfWs('E2E WebSocket Tests', () => {
 
     test('regular rpc endpoint', async () => {
       const response = await webSocketChannel.sendReceive('starknet_chainId');
-      expect(response).toBe(StarknetChainId.SN_SEPOLIA);
+      expect(response).toBe(expectedChainId);
     });
   });
 
@@ -493,7 +563,7 @@ describeIfWs('E2E WebSocket Tests', () => {
             .sendReceive('starknet_chainId')
             .then((result) => {
               // 3. This assertion runs after reconnection, proving the queue was processed.
-              expect(result).toBe(StarknetChainId.SN_SEPOLIA);
+              expect(result).toBe(expectedChainId);
               done(); // 4. Test is done when the queued request has been successfully processed.
             })
             // Report the failure rather than leave `done()` uncalled: a queued request has no
@@ -729,6 +799,193 @@ describe('Unit Test: Subscription Class', () => {
     // And the subscription should be removed from the channel once.
     expect(mockChannel.removeSubscription).toHaveBeenCalledTimes(1);
     expect(mockChannel.removeSubscription).toHaveBeenCalledWith('sub_123');
+  });
+
+  test('unsubscribe stays idempotent when called again before the first reply', async () => {
+    // The sequential test above never exercises the window that matters: `unsubscribe()`
+    // closes the subscription only after the round-trip, so a second caller arriving while
+    // the first request is still on the wire passes the guard too and sends a duplicate
+    // `starknet_unsubscribe`. That happens for real whenever a node pushes two events in one
+    // burst and the handler unsubscribes on each — the second request is then still in flight
+    // when the channel is closed, and settles as an unhandled rejection.
+    let reply: (value: boolean) => void;
+    mockChannel.unsubscribe = jest.fn().mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        reply = resolve;
+      })
+    );
+
+    const first = subscription.unsubscribe();
+    const second = subscription.unsubscribe();
+    reply!(true);
+
+    await expect(first).resolves.toBe(true);
+    await expect(second).resolves.toBe(true);
+    expect(mockChannel.unsubscribe).toHaveBeenCalledTimes(1);
+    expect(mockChannel.removeSubscription).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('Unit Test: WebSocketChannel subscription lifecycle', () => {
+  let webSocketChannel: WebSocketChannel;
+
+  beforeAll(() => {
+    config.set('websocket', ScriptedWebSocket as any);
+  });
+
+  afterAll(() => {
+    config.set('websocket', undefined as any);
+  });
+
+  afterEach(() => {
+    webSocketChannel?.disconnect();
+  });
+
+  test('an event arriving in the same burst as the subscription reply is not lost', async () => {
+    // The subscription id only exists once the reply arrives, and the continuation that
+    // registers it runs a microtask later. An event flushed in the same burst is therefore
+    // looked up before that registration and, without a fix, dropped with nothing but a
+    // warning — a silent hole that no assertion in the E2E suite can see.
+    webSocketChannel = new WebSocketChannel({ nodeUrl: 'wss://mock', autoReconnect: false });
+    const ws = ScriptedWebSocket.current;
+
+    const pending = webSocketChannel.subscribeNewHeads();
+
+    ws.deliver(
+      { jsonrpc: '2.0', id: 0, result: 'SUB_1' },
+      {
+        jsonrpc: '2.0',
+        method: 'starknet_subscriptionNewHeads',
+        params: { subscription_id: 'SUB_1', result: { block_number: 42 } },
+      }
+    );
+
+    const sub = await pending;
+    const handler = jest.fn();
+    sub.on(handler); // Attaching flushes whatever was buffered before the handler existed.
+
+    expect(handler).toHaveBeenCalledWith({ block_number: 42 });
+  });
+
+  test('an event for a genuinely unknown subscription is still discarded', async () => {
+    webSocketChannel = new WebSocketChannel({ nodeUrl: 'wss://mock', autoReconnect: false });
+    const ws = ScriptedWebSocket.current;
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    ws.deliver({
+      jsonrpc: '2.0',
+      method: 'starknet_subscriptionNewHeads',
+      params: { subscription_id: 'NEVER_SUBSCRIBED', result: { block_number: 1 } },
+    });
+
+    // Deferred delivery must not turn "unknown id" into a leak: once the retry finds nothing,
+    // the event is dropped and reported, exactly as before.
+    await Promise.resolve();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('untracked subscription ID: NEVER_SUBSCRIBED')
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  test('a subscription that cannot be restored stops reporting itself as live', async () => {
+    // A reconnection re-subscribes every active subscription. One that fails was dropped from
+    // the channel with nothing but a log line, while the `Subscription` the caller holds kept
+    // saying it was open — with a handler attached that would never be called again.
+    webSocketChannel = new WebSocketChannel({ nodeUrl: 'wss://mock', autoReconnect: false });
+    const ws = ScriptedWebSocket.current;
+    const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+
+    const pending = webSocketChannel.subscribeNewHeads();
+    ws.deliver({ jsonrpc: '2.0', id: 0, result: 'SUB_1' });
+    const sub = await pending;
+    expect(sub.isClosed).toBe(false);
+
+    const restoring = (webSocketChannel as any)._restoreSubscriptions();
+    ws.deliver({ jsonrpc: '2.0', id: 1, error: { code: 1, message: 'subscription refused' } });
+    await restoring;
+
+    expect(sub.isClosed).toBe(true);
+    expect(errorSpy).toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+});
+
+describe('Unit Test: WebSocketChannel waitForUnsubscription', () => {
+  let webSocketChannel: WebSocketChannel;
+
+  beforeAll(() => {
+    config.set('websocket', ScriptedWebSocket as any);
+  });
+
+  afterAll(() => {
+    config.set('websocket', undefined as any);
+  });
+
+  afterEach(() => {
+    webSocketChannel?.disconnect();
+  });
+
+  /** Opens a channel and completes one subscription, leaving the reply id counter at 1. */
+  const subscribed = async () => {
+    webSocketChannel = new WebSocketChannel({ nodeUrl: 'wss://mock', autoReconnect: false });
+    const ws = ScriptedWebSocket.current;
+    const pending = webSocketChannel.subscribeNewHeads();
+    ws.deliver({ jsonrpc: '2.0', id: 0, result: 'SUB_1' });
+    return { ws, sub: await pending };
+  };
+
+  /** Records how a promise settled without ever leaving it unhandled. */
+  const track = (promise: Promise<unknown>) => {
+    const state = { settled: undefined as 'resolved' | 'rejected' | undefined };
+    promise.then(
+      () => {
+        state.settled = 'resolved';
+      },
+      () => {
+        state.settled = 'rejected';
+      }
+    );
+    return state;
+  };
+
+  test('resolves once the subscription is unsubscribed', async () => {
+    const { ws, sub } = await subscribed();
+
+    const waiting = track(webSocketChannel.waitForUnsubscription(sub.id));
+    const unsubscribing = sub.unsubscribe();
+    ws.deliver({ jsonrpc: '2.0', id: 1, result: true });
+
+    await expect(unsubscribing).resolves.toBe(true);
+    await withTimeout(Promise.resolve(), 0);
+    expect(waiting.settled).toBe('resolved');
+  });
+
+  test('rejects when the node refuses the unsubscribe', async () => {
+    // `unsubscribe` only announces success, so a `false` reply left every waiter pending
+    // forever — and a caller awaiting it had no timeout of its own to fall back on.
+    const { ws, sub } = await subscribed();
+
+    const waiting = track(webSocketChannel.waitForUnsubscription(sub.id));
+    const unsubscribing = sub.unsubscribe();
+    ws.deliver({ jsonrpc: '2.0', id: 1, result: false });
+
+    await expect(unsubscribing).resolves.toBe(false);
+    await withTimeout(Promise.resolve(), 0);
+    expect(waiting.settled).toBe('rejected');
+  });
+
+  test('rejects when the connection closes while waiting', async () => {
+    // After a close the unsubscribe can never be observed: a reconnection restores the
+    // subscription under a new id, so this one will never be announced.
+    const { sub } = await subscribed();
+
+    const waiting = track(webSocketChannel.waitForUnsubscription(sub.id));
+    webSocketChannel.disconnect();
+
+    await withTimeout(Promise.resolve(), 0);
+    expect(waiting.settled).toBe('rejected');
   });
 });
 

--- a/src/channel/ws/subscription.ts
+++ b/src/channel/ws/subscription.ts
@@ -84,6 +84,9 @@ export class Subscription<T = any> {
 
   private _isClosed = false;
 
+  // The unsubscribe request currently on the wire, shared by concurrent callers.
+  private pendingUnsubscribe: Promise<boolean> | null = null;
+
   /**
    * @internal
    * @param options - Subscription configuration options
@@ -102,6 +105,21 @@ export class Subscription<T = any> {
    */
   public get isClosed(): boolean {
     return this._isClosed;
+  }
+
+  /**
+   * Closes the subscription locally, without contacting the node.
+   *
+   * Used when the channel knows the subscription is gone and cannot be recovered — a
+   * re-subscribe refused after a reconnection, for instance. Without it the object would keep
+   * reporting itself as open while no event could ever reach its handler again.
+   * @internal
+   */
+  public _markClosed(): void {
+    if (this._isClosed) return;
+    this._isClosed = true;
+    this.events.emit('unsubscribe', undefined);
+    this.events.clear();
   }
 
   /**
@@ -156,13 +174,33 @@ export class Subscription<T = any> {
     if (this._isClosed) {
       return true; // Already unsubscribed, treat as success.
     }
-    const success = await this.channel.unsubscribe(this.id);
-    if (success) {
-      this._isClosed = true;
-      this.channel.removeSubscription(this.id);
-      this.events.emit('unsubscribe', undefined);
-      this.events.clear(); // Clean up all listeners.
+    // Concurrent callers share the request already on the wire. The `_isClosed` guard above
+    // only closes once the round-trip completes, so without this a caller arriving before the
+    // reply passes it too and sends a second `starknet_unsubscribe`. That happens for real
+    // whenever a node pushes several events in one burst and the handler unsubscribes on each:
+    // the node answers the first request and ignores the rest, leaving them on the wire until
+    // the connection closes — at which point they settle as unhandled rejections.
+    if (this.pendingUnsubscribe) {
+      return this.pendingUnsubscribe;
     }
-    return success;
+
+    this.pendingUnsubscribe = (async () => {
+      try {
+        const success = await this.channel.unsubscribe(this.id);
+        if (success) {
+          this._isClosed = true;
+          this.channel.removeSubscription(this.id);
+          this.events.emit('unsubscribe', undefined);
+          this.events.clear(); // Clean up all listeners.
+        }
+        return success;
+      } finally {
+        // Released so a failed attempt can be retried; after a successful one the `_isClosed`
+        // guard short-circuits before ever reaching here again.
+        this.pendingUnsubscribe = null;
+      }
+    })();
+
+    return this.pendingUnsubscribe;
   }
 }

--- a/src/channel/ws/ws_0_10.ts
+++ b/src/channel/ws/ws_0_10.ts
@@ -219,6 +219,19 @@ export class WebSocketChannel {
   /** Abort handles for the requests currently on the wire, one per pending `sendReceive`. */
   private inFlight = new Set<(reason: string) => void>();
 
+  /**
+   * Callers blocked in `waitForUnsubscription`, keyed by subscription id.
+   *
+   * Held here rather than as `unsubscribe` event listeners because that event only ever
+   * announces success: a waiter attached to it cannot learn that the node refused the
+   * unsubscribe or that the connection went away, and would wait forever with no timeout of
+   * its own to fall back on.
+   */
+  private unsubscribeWaiters = new Map<
+    SUBSCRIPTION_ID,
+    Set<{ resolve: () => void; reject: (error: Error) => void }>
+  >();
+
   private events = new EventEmitter<WebSocketChannelEvents>();
 
   private openListener = (ev: Event) => {
@@ -469,6 +482,7 @@ export class WebSocketChannel {
     this.isReconnecting = false;
     this._rejectRequestQueue('the connection was closed by the user');
     this._rejectInFlight('the connection was closed by the user');
+    this._rejectUnsubscribeWaiters('the connection was closed by the user');
     this.websocket.close(code, reason);
   }
 
@@ -497,13 +511,49 @@ export class WebSocketChannel {
    * @returns {Promise<boolean>} A Promise that resolves with `true` if the unsubscription was successful.
    */
   public async unsubscribe(subscriptionId: SUBSCRIPTION_ID) {
-    const status = await this.sendReceive<boolean>('starknet_unsubscribe', {
-      subscription_id: subscriptionId,
-    });
+    let status: boolean;
+    try {
+      status = await this.sendReceive<boolean>('starknet_unsubscribe', {
+        subscription_id: subscriptionId,
+      });
+    } catch (error) {
+      this._settleUnsubscribeWaiters(subscriptionId, error as Error);
+      throw error;
+    }
     if (status) {
       this.events.emit('unsubscribe', subscriptionId);
+      this._settleUnsubscribeWaiters(subscriptionId);
+    } else {
+      this._settleUnsubscribeWaiters(
+        subscriptionId,
+        new Error(`Node refused to unsubscribe subscription ${subscriptionId}`)
+      );
     }
     return status;
+  }
+
+  /** Settles every caller waiting on one subscription id: resolved, or rejected with `error`. */
+  private _settleUnsubscribeWaiters(subscriptionId: SUBSCRIPTION_ID, error?: Error): void {
+    const waiters = this.unsubscribeWaiters.get(subscriptionId);
+    if (!waiters) return;
+    this.unsubscribeWaiters.delete(subscriptionId);
+    waiters.forEach((waiter) => (error ? waiter.reject(error) : waiter.resolve()));
+  }
+
+  /**
+   * Rejects every caller still waiting on any subscription.
+   *
+   * Once the connection is gone, no unsubscribe can be observed on it: a reconnection restores
+   * each subscription under a fresh id, so the id being waited on will never be announced.
+   */
+  private _rejectUnsubscribeWaiters(reason: string): void {
+    if (this.unsubscribeWaiters.size === 0) return;
+    Array.from(this.unsubscribeWaiters.keys()).forEach((id) =>
+      this._settleUnsubscribeWaiters(
+        id,
+        new WebSocketNotConnectedError(`Subscription ${id} was never unsubscribed: ${reason}`)
+      )
+    );
   }
 
   /**
@@ -517,14 +567,10 @@ export class WebSocketChannel {
    * ```
    */
   public waitForUnsubscription(targetId: SUBSCRIPTION_ID): Promise<void> {
-    return new Promise((resolve) => {
-      const listener = (unsubId: SUBSCRIPTION_ID) => {
-        if (unsubId === targetId) {
-          this.events.off('unsubscribe', listener);
-          resolve();
-        }
-      };
-      this.events.on('unsubscribe', listener);
+    return new Promise((resolve, reject) => {
+      const waiters = this.unsubscribeWaiters.get(targetId) ?? new Set();
+      waiters.add({ resolve, reject });
+      this.unsubscribeWaiters.set(targetId, waiters);
     });
   }
 
@@ -606,7 +652,9 @@ export class WebSocketChannel {
         logger.info(`Subscription ${sub.method} restored with new ID: ${newSubId}`);
       } catch (error) {
         logger.error(`Failed to restore subscription ${sub.method}:`, error);
-        // The subscription is not added back to activeSubscriptions if it fails
+        // Not added back to activeSubscriptions — and closed, so the handle the caller still
+        // holds stops claiming to be live when nothing will ever be delivered to it again.
+        sub._markClosed();
       }
     });
 
@@ -712,6 +760,7 @@ export class WebSocketChannel {
     // after `disconnect()`, which drains them before closing — the closing handshake itself is
     // not guaranteed to complete.
     this._rejectInFlight('the connection was closed');
+    this._rejectUnsubscribeWaiters('the connection was closed');
     this.events.emit('close', ev);
 
     if (!this.userInitiatedClose) {
@@ -741,9 +790,22 @@ export class WebSocketChannel {
       if (subscription) {
         subscription._handleEvent(result);
       } else {
-        logger.warn(
-          `WebSocketChannel: Received event for untracked subscription ID: ${subscription_id}.`
-        );
+        // The registration for this id can still be one microtask away: the reply carrying it
+        // and this event may be flushed in the same burst, and the continuation that registers
+        // the subscription has not run yet. Retry once at the end of the current tick — the
+        // continuation was queued first, so it wins — then give up, so an id that genuinely
+        // does not exist is still dropped. Events deferred this way keep their relative order,
+        // and any event arriving in a later tick is necessarily delivered after them.
+        queueMicrotask(() => {
+          const registered = this.activeSubscriptions.get(subscription_id);
+          if (registered) {
+            registered._handleEvent(result);
+          } else {
+            logger.warn(
+              `WebSocketChannel: Received event for untracked subscription ID: ${subscription_id}.`
+            );
+          }
+        });
       }
     }
 

--- a/www/docs/guides/websocket_channel.md
+++ b/www/docs/guides/websocket_channel.md
@@ -272,6 +272,9 @@ If the connection drops, the channel reconnects with an exponential backoff, re-
 active streams — your existing `Subscription` objects keep working, with nothing to do on your side —
 then flushes the queued requests.
 
+A stream the node refuses to re-subscribe cannot be recovered: its `Subscription` is closed, and
+`isClosed` reports it.
+
 The defaults are usually fine; tune them if needed:
 
 ```typescript
@@ -308,7 +311,7 @@ try {
   if (error instanceof TimeoutError) {
     console.error('No answer from the node in time');
   } else if (error instanceof WebSocketNotConnectedError) {
-    console.error('Socket closed and auto-reconnect disabled');
+    console.error('The connection is gone, the request will not be answered');
   } else {
     throw error;
   }


### PR DESCRIPTION
## Motivation and Resolution

The WebSocket channel carried four instances of one defect: a guard read before an `await`, and the state it protects written after. Each surfaced only under a particular node's timing, which is why they were found one at a time across the 10.6.x series — a red CI exposed one occurrence, that occurrence got fixed, and the next waited its turn.

The one that opened this round: when a node pushes two subscription events in a single burst, a handler that unsubscribes calls `Subscription.unsubscribe()` twice. `_isClosed` is only set once the round-trip completes, so both calls pass the guard and a duplicate `starknet_unsubscribe` goes out. The node answers the first and ignores the second, which then sits on the wire until the connection closes and settles as an unhandled rejection. Pathfinder sends two transaction statuses where Juno sends one — hence the same test passing on one node and failing on the other.

Rather than patch that single occurrence, this PR closes the family. Every fix here is preceded by a test that fails without it, and each of those tests runs against a scripted WebSocket — no node, no network — so its verdict cannot depend on which gateway CI happens to reach.

It also removes the last network assumption from the suite: three assertions hardcoded `SN_SEPOLIA` and failed on any run against another network.

### RPC version (if applicable)

Not applicable — no change to the RPC spec surface.

## Usage related changes

- `Subscription.unsubscribe()` — concurrent callers now share the request already on the wire instead of each sending their own `starknet_unsubscribe`.
- A subscription event delivered in the same burst as the subscribe reply is no longer lost. The subscription id only exists once the reply arrives, and the continuation that registers it runs a microtask later; such an event used to be looked up too early and discarded with nothing but a warning.
- `waitForUnsubscription()` now rejects instead of never settling — both when the node refuses the unsubscribe and when the connection closes while waiting. This is the one change that can surprise existing code: a promise that used to hang forever now produces a rejection.
- A subscription that cannot be restored after a reconnection now reports `isClosed === true`, instead of leaving the caller a live-looking handle whose handler will never fire again.

## Development related changes

- Nine unit tests added, driven by a scripted WebSocket that delivers frames in a controlled synchronous burst — the window no live node reproduces on demand. They need no node and cover concurrent unsubscribe, same-burst event delivery, discarding of genuinely unknown subscription ids, a failed restore, and the three `waitForUnsubscription` outcomes.
- The E2E suite no longer hardcodes the chain id; it reads it from the RPC provider once. The assertion is stronger as a result: it now checks that the WebSocket and HTTP channels agree on the chain, rather than comparing against a literal.

Verified against two local nodes — Pathfinder / Sepolia / v0.10 and Juno / Mainnet / v0.10: 39/39 tests pass on both, with no Jest hang.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
