### PR TITLE
fix(shortString): zero-pad each byte in encodeShortString

### DIFF
--- a/__tests__/utils/shortString.test.ts
+++ b/__tests__/utils/shortString.test.ts
@@ -12,6 +12,14 @@ describe('shortString', () => {
     expect(encodeShortString('hello')).toMatchInlineSnapshot(`"0x68656c6c6f"`);
   });
 
+  test('should zero-pad control chars and round-trip', () => {
+    // 0x09 (tab) is a valid ASCII char < 0x10; without padding it would emit a
+    // single nibble and misalign every following byte.
+    expect(encodeShortString('a\tb')).toBe('0x610962');
+    expect(decodeShortString(encodeShortString('a\tb'))).toBe('a\tb');
+    expect(decodeShortString(encodeShortString('a\nb'))).toBe('a\nb');
+  });
+
   test('should throw if string to encode is too long', () => {
     expect(() =>
       encodeShortString('hello world hello world hello world hello world hello world hello world')

--- a/src/utils/shortString.ts
+++ b/src/utils/shortString.ts
@@ -119,7 +119,9 @@ export function splitLongString(longStr: string): string[] {
 export function encodeShortString(str: string): string {
   if (!isASCII(str)) throw new Error(`${str} is not an ASCII string`);
   if (!isShortString(str)) throw new Error(`${str} is too long`);
-  return addHexPrefix(str.replace(/./g, (char) => char.charCodeAt(0).toString(16)));
+  return addHexPrefix(
+    str.replace(/[\s\S]/g, (char) => char.charCodeAt(0).toString(16).padStart(2, '0'))
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

`encodeShortString` builds the felt hex with `charCodeAt(0).toString(16)` and no zero-padding:

```ts
str.replace(/./g, (char) => char.charCodeAt(0).toString(16))
```

For any ASCII character below `0x10` (tab `0x09`, and other control chars that `isASCII` accepts), this emits a single hex nibble, which misaligns every following byte and yields the wrong felt. Newlines (`0x0A`/`0x0D`) are not matched by `.` at all, so they pass through verbatim and later break `BigInt`.

```
encodeShortString('a\tb')  ->  0x61962   (wrong, felt 399714)
correct                    ->  0x610962  (felt 6359394)
decodeShortString(encodeShortString('a\tb'))  ->  'a2'   (not 'a\tb')
```

This reaches the typed-data (SNIP-12) signing path: `typedData.ts getHex` routes felt/shortstring string values through `encodeShortString`, so a control character in a signed field produces a wrong message hash.

## Fix

Pad each byte to two hex digits and match all characters including newlines:

```ts
str.replace(/[\s\S]/g, (char) => char.charCodeAt(0).toString(16).padStart(2, '0'))
```

Regression-safe: for printable characters (code >= 0x20) the output already had two hex digits, so `padStart` is a no-op and all existing outputs are unchanged.

## Test

Added a control-char round-trip test (`'a\tb'` encodes to `0x610962` and decodes back, plus a newline case). The existing tests only cover printable strings, so this path was uncovered.
