### PR TITLE
docs: migration guide v10 -> v11

### DIFF
--- a/www/docs/guides/account/signature.md
+++ b/www/docs/guides/account/signature.md
@@ -13,7 +13,7 @@ Your message has to be an array of `BigNumberish`. First, calculate the hash of 
 > If the message does not respect some safety rules of composition, this method could be a way of attack of your smart contract. If you have any doubt, prefer the [EIP712 like method](#sign-and-verify-following-eip712), which is safe, but is also more complicated.
 
 ```typescript
-import { ec, hash, type BigNumberish, type WeierstrassSignatureType } from 'starknet';
+import { ec, hash, stark, type BigNumberish, type WeierstrassSignatureType } from 'starknet';
 
 const privateKey = '0x1234567890987654321';
 const starknetPublicKey = ec.starkCurve.getStarkKey(privateKey);
@@ -103,7 +103,11 @@ const myProvider = new RpcProvider({ nodeUrl: 'http://127.0.0.1:5050/rpc' }); //
 const accountAddress = '0x...'; // account of sender
 
 const msgHash2 = hash.computeHashOnElements(message);
-const result2: Boolean = rpcProvider.verifyMessageInStarknet(msgHash2, signature, accountAddress);
+const result2: Boolean = await myProvider.verifyMessageInStarknet(
+  msgHash2,
+  signature,
+  accountAddress
+);
 console.log('Result (boolean) =', result2);
 ```
 

--- a/www/docs/guides/configuration.md
+++ b/www/docs/guides/configuration.md
@@ -19,7 +19,7 @@ import { config } from 'starknet';
 // Set existing or custom global property
 config.set('rpcVersion', '0.9.0');
 
-// Set WebSocket implementation for Node.js (if using older than Node.js 22)
+// Set WebSocket implementation for Node.js (if using older than Node.js 22.11)
 import WebSocket from 'ws';
 config.set('websocket', WebSocket);
 

--- a/www/docs/guides/migrate.md
+++ b/www/docs/guides/migrate.md
@@ -2,849 +2,304 @@
 sidebar_position: 12
 ---
 
-# Migrate from v9 to v10
+# Migrate from v10 to v11
 
-This document covers the breaking changes in v10 and how to migrate your code.
+This guide covers every breaking change between v10 (10.7.0) and v11, and how to resolve it. Two
+shorter parts follow: the deprecations, which break nothing today, and what v11 adds.
 
-If you encounter any missing changes, please let us know and we will update this guide.
+If you hit a change that is not described here, please tell us and we will complete this guide.
 
-## Quick Summary
+## Quick summary
 
-**Main breaking changes in v10:**
+v11 carries two independent workstreams. The cryptographic dependencies move to their v2, ESM-only
+generation (`@noble/curves` 1.7 → 2.3, `@noble/hashes` 1.6 → 2.3, `@scure/base` 1.2 → 2.3,
+`@scure/starknet` 1.1 → 2.3), and RPC requests now travel through a pluggable transport, which lets
+a single WebSocket serve both requests and subscriptions.
 
-1. **Account Composition** - Account no longer extends Provider, uses composition instead
-2. **Plugin Class Names** - `StarknetId` → `StarknetIdImpl`, `BrotherId` → `BrotherIdImpl`
-3. **Plugin Import Paths** - `provider/extensions/` → package root
-4. **Compression Functions** - `compressProgram()` and `decompressProgram()` are now async
-5. **SimulateTransaction Response** - `SimulateTransactionOverheadResponse` changed from array to object
-6. **Provider fetch() Method** - Now `async` (low impact)
-7. **Removed Global Singletons** - `defaultProvider` and `defaultPaymaster` removed, use `RpcProvider.create()` instead
-8. **ts-mixer Removed** - No longer a dependency
-9. **getStorageAt() Return Type** - Now returns `STORAGE_RESULT` object instead of `string`
-10. **fastExecute Moved to a Plugin** - `account.fastExecute()` and `provider.fastWaitForTransaction()` now come from the `fastExecute` plugin
-11. **Paymaster Option Renamed** - `PaymasterRpcOptions.default` → `mute`
-12. **felt252 Validation** - `CairoFelt()` now throws on out-of-range values, and `CairoFelt252.toApiRequest()` returns decimal
-13. **RPC Namespace Renames** - `RPCSPEC010` → `RPCSPEC0103`, `RPC010` → `RPC0102` / `RPC0103`
+**Only the first one breaks anything.** The transport layer is added underneath the existing API,
+which is why the list below is short.
 
-### Breaking Changes Summary
+| Change                                           | Severity   | What you have to do                            |
+| ------------------------------------------------ | ---------- | ---------------------------------------------- |
+| Node.js >= 22.12 is now required                 | **High**   | Upgrade Node, or use the ESM build             |
+| Jest: the crypto dependencies are ESM-only       | **High**   | Add one line to your `transformIgnorePatterns` |
+| Signature objects lost their v1 encoding methods | **Medium** | Rename `toDERHex()` and its three siblings     |
+| `@noble` / `@scure` import paths changed         | **Low**    | Only if you import these packages directly     |
 
-| Change                                                           | Severity   | Impact                                                    |
-| ---------------------------------------------------------------- | ---------- | --------------------------------------------------------- |
-| Account composition (`account.xyz()` → `account.provider.xyz()`) | **High**   | All provider method calls on Account must be updated      |
-| Removed `defaultProvider` and `defaultPaymaster` singletons      | **Medium** | Use `await RpcProvider.create()` or `new PaymasterRpc()`  |
-| `getStorageAt()` returns object instead of string                | **Medium** | Must use `.value` property to access FELT value           |
-| Compression functions now async (`await compressProgram()`)      | **Medium** | Also `parseContract()` and the contract-class helpers     |
-| Plugin class renames (`StarknetId` → `StarknetIdImpl`)           | **Medium** | Only affects direct imports of these classes              |
-| Plugin import paths (`extensions/` → package root)               | **Medium** | Only affects direct imports                               |
-| `SimulateTransactionOverheadResponse` is now an object           | **Medium** | Must access `.simulated_transactions` for the array       |
-| `fastExecute` is now a plugin                                    | **Medium** | Types renamed; methods disappear with `plugins: false`    |
-| `RPCSPEC010` / `RPC010` namespaces renamed                       | **Medium** | Only affects raw spec types and direct channel imports    |
-| `PaymasterRpcOptions.default` renamed to `mute`                  | **Low**    | Only affects manual `PaymasterRpc` construction           |
-| felt252 range validation is now enforced                         | **Low**    | Out-of-range values used to pass silently, they now throw |
-| `Storage` response type renamed to `StorageResponse`             | **Low**    | Only affects code importing the type                      |
-| Removed `default` parameter from RPC options                     | **Low**    | Parameter was only used by removed singletons             |
-| `fetch()` is now `async`                                         | **Low**    | Already returned Promise, minimal impact                  |
-| `ts-mixer` and `pako` removed                                    | **Low**    | Only affects if you used them as transitive dependencies  |
-| `plugins: false` disables defaults                               | **Info**   | Behavioral change, intentional opt-out                    |
+Two deprecations ship with the release — `stark.randomAddress()` and `Provider` — but neither of
+them breaks existing code. They are covered in [Part 2](#part-2--deprecations).
 
-**Quick migration steps:**
+### What did not change
+
+Worth stating, because the release is a major: `Account`, `Contract`, `CallData`, the Cairo type
+helpers and the `Signer` interface are untouched. `WebSocketChannel` keeps exactly the API it had in
+v10 — same constructor options, same `subscribe*` methods, same events. No RPC spec version is added
+or dropped: 0.9 and 0.10.x remain supported, with 0.10.3 as the default. And nothing was removed
+from the package exports.
+
+### Migration in three minutes
 
 ```bash
-# Update package
-npm install starknet@^10.0.0
+# while v11 is in beta
+npm install starknet@beta
+
+# once v11 is released
+npm install starknet@^11.0.0
 ```
 
 ```typescript
-// Update Account provider method calls
-const receipt = await account.provider.waitForTransaction(txHash); // ✅ Was account.waitForTransaction()
-const storage = await account.provider.getStorageAt(address, key); // ✅ Was account.getStorageAt()
-const chainId = await account.provider.getChainId(); // ✅ Was account.getChainId()
+// Verifying a signature: the encoding step is gone
+const isValid = ec.starkCurve.verify(signature, msgHash, pubKey); // ✅ was signature.toDERHex()
 
-// Plugin methods still work directly on account (no change needed)
-const name = await account.getStarkName(); // ✅ Still works
-const address = await account.getAddressFromStarkName('example.stark'); // ✅ Still works
-
-// Update plugin imports (only if you import them directly)
-import { StarknetIdImpl } from 'starknet'; // ✅ Was StarknetId
-import { BrotherIdImpl } from 'starknet'; // ✅ Was BrotherId
+// Recommended, not required — both of these still work as before
+const privateKey = stark.randomStarkPrivateKey(); // was stark.randomAddress()
 ```
 
-## Breaking Change 1: Account Composition
+And, if your project is tested with Jest, in `jest.config.js`:
 
-### What Changed
+```javascript
+transformIgnorePatterns: ['node_modules/(?!(@noble|@scure)/)'],
+```
 
-In v9, `Account` extended `Provider`, giving direct access to all provider methods:
+## Part 1 — Breaking changes
 
-**❌ v9 (no longer works):**
+Ordered by how likely you are to hit them.
+
+### 1. Node.js >= 22.12 is now required
+
+The `engines` field moves from `>=22` to `>=22.12`.
+
+The crypto dependencies are ESM-only in their v2 generation, and the CJS build of starknet.js
+`require()`s them. Node only supports requiring an ESM module from 22.12 onwards. On Node 22.0 to
+22.11, `require('starknet')` therefore fails:
+
+```
+Error [ERR_REQUIRE_ESM]: require() of ES Module …
+```
+
+**Resolution:** upgrade to Node 22.12 or later — the maintained 22.x line is well past it, so
+`nvm install 22` is enough.
+
+ESM consumers (`import` / `"type": "module"`) and the browser IIFE build are **not** affected, and
+work on any Node 22.
+
+### 2. Jest: the crypto dependencies must be transformed
+
+Jest ignores `node_modules` when transforming, so the ESM-only `@noble/*` and `@scure/*` packages
+reach the runtime untranspiled. Importing starknet.js from a test then fails with:
+
+```
+SyntaxError: Unexpected token 'export'
+```
+
+**Resolution:** allow these two scopes through, in your own Jest configuration:
+
+```javascript
+// jest.config.js
+module.exports = {
+  // …
+  transformIgnorePatterns: ['node_modules/(?!(@noble|@scure)/)'],
+};
+```
+
+**Vitest needs no change** — it transforms ESM dependencies by default.
+
+One consequence, if you spy on the crypto packages: their exports are now non-configurable ESM
+getters, which `jest.spyOn()` cannot redefine. Replace the module with a writable copy of itself
+first, keeping the real implementations:
 
 ```typescript
-const account = new Account({ provider, address, signer: privateKey });
-
-await account.waitForTransaction(txHash);
-await account.getBlock('latest');
-await account.getChainId();
+jest.mock('@scure/starknet', () => ({
+  __esModule: true,
+  ...jest.requireActual('@scure/starknet'),
+}));
 ```
 
-**✅ v10:**
+### 3. Signature objects are plain `ECDSASignature` values
+
+`WeierstrassSignatureType` was an alias of `weierstrass.SignatureType`, the `@noble/curves` v1
+signature **class**. It is now an alias of `weierstrass.ECDSASignature`, which carries `r`, `s` and
+an optional `recovery`, plus a smaller set of methods.
+
+Reading `signature.r` and `signature.s` is unchanged, and so is everything starknet.js does with a
+signature on your behalf — `account.execute()`, `signer.signMessage()`, `stark.formatSignature()`.
+Only code calling methods **on the returned object** has to be adapted:
+
+| v10                   | v11                  |
+| --------------------- | -------------------- |
+| `toDERHex()`          | `toHex('der')`       |
+| `toDERRawBytes()`     | `toBytes('der')`     |
+| `toCompactHex()`      | `toHex('compact')`   |
+| `toCompactRawBytes()` | `toBytes('compact')` |
+| `normalizeS()`        | removed              |
+| `assertValidity()`    | removed              |
+
+The most common occurrence is a signature verification, where the encoding step is simply no longer
+needed — `verify()` accepts the signature object itself:
+
+**❌ v10:**
 
 ```typescript
-const account = new Account({ provider, address, signer: privateKey });
-
-// Provider methods now require .provider
-await account.provider.waitForTransaction(txHash);
-await account.provider.getBlock('latest');
-await account.provider.getChainId();
-
-// Account methods still work directly
-await account.execute(calls);
-await account.signMessage(typedData);
+const signature = ec.starkCurve.sign(msgHash, privateKey);
+const isValid = ec.starkCurve.verify(signature.toDERHex(), msgHash, publicKey);
 ```
 
-### Why This Change?
-
-The composition pattern provides:
-
-- **Clear separation** - Account handles account operations, Provider handles blockchain queries
-- **Better type safety** - No method signature conflicts
-- **Plugin compatibility** - Plugins can extend Account without inheritance issues
-
-### Migration Guide
-
-Update all provider method calls on Account instances to use `.provider`:
+**✅ v11:**
 
 ```typescript
-// Block & State queries
-account.getBlock() → account.provider.getBlock()
-account.getBlockWithTxHashes() → account.provider.getBlockWithTxHashes()
-account.getStateUpdate() → account.provider.getStateUpdate()
-account.getStorageAt() → account.provider.getStorageAt()
-
-// Transaction queries
-account.getTransaction() → account.provider.getTransaction()
-account.getTransactionReceipt() → account.provider.getTransactionReceipt()
-account.waitForTransaction() → account.provider.waitForTransaction()
-
-// Contract & Class queries
-account.getClassAt() → account.provider.getClassAt()
-account.getClassByHash() → account.provider.getClassByHash()
-account.getClassHashAt() → account.provider.getClassHashAt()
-account.callContract() → account.provider.callContract()
-
-// Network queries
-account.getChainId() → account.provider.getChainId()
-account.getSpecVersion() → account.provider.getSpecVersion()
+const signature = ec.starkCurve.sign(msgHash, privateKey);
+const isValid = ec.starkCurve.verify(signature, msgHash, publicKey);
 ```
 
-**These methods DON'T need changes** (they're account-specific):
+`recoverPublicKey()`, `hasHighS()` and `addRecoveryBit()` are still there, unchanged. And
+`ec.starkCurve.sign()` still returns an instance of `ec.starkCurve.Signature`, so an `instanceof`
+test against it keeps working.
+
+### 4. `@noble` / `@scure` import paths changed
+
+This one only concerns you if you import these packages **directly**, alongside starknet.js. Their
+v2 generation requires explicit `.js` suffixes, and moved some entry points:
+
+| v10                                  | v11                                     |
+| ------------------------------------ | --------------------------------------- |
+| `@noble/curves/abstract/utils`       | `@noble/curves/utils.js`                |
+| `@noble/curves/secp256k1`            | `@noble/curves/secp256k1.js`            |
+| `@noble/curves/abstract/weierstrass` | `@noble/curves/abstract/weierstrass.js` |
+| `@noble/hashes/sha256`               | `@noble/hashes/sha2.js`                 |
+| `@noble/hashes/sha3`                 | `@noble/hashes/sha3.js`                 |
+| `@noble/hashes/blake2s`              | `@noble/hashes/blake2.js`               |
+
+Two API changes come with them:
+
+**Hash functions no longer accept a string.** Encode it first:
 
 ```typescript
-// Execution & signing (no change)
-account.execute(calls);
-account.declare(contract);
-account.deploy(payload);
-account.signMessage(typedData);
+import { sha256 } from '@noble/hashes/sha2.js';
+import { utf8ToBytes } from '@noble/hashes/utils.js';
 
-// Fee estimation (no change)
-account.estimateInvokeFee(calls);
-account.estimateDeclareFee(contract);
-
-// Account queries (no change)
-account.getNonce();
-account.getCairoVersion();
-
-// Plugin methods (no change)
-account.getStarkName();
-account.getAddressFromStarkName('name.stark');
+const digest = sha256(utf8ToBytes('hello')); // ✅ was sha256('hello')
 ```
 
-## Breaking Change 2: Removed Global Singletons
-
-### What Changed
-
-In v10, the global singleton exports `defaultProvider` and `defaultPaymaster` have been removed to promote explicit initialization and better resource management.
-
-**❌ v9 (no longer works):**
+**`randomPrivateKey()` is renamed on the noble curves.** On secp256k1:
 
 ```typescript
-import { defaultProvider, defaultPaymaster } from 'starknet';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
 
-// These no longer exist
-const result = await defaultProvider.getBlock('latest');
-const tokens = await defaultPaymaster.getSupportedTokens();
+const key = secp256k1.utils.randomSecretKey(); // ✅ was randomPrivateKey()
 ```
 
-**✅ v10:**
+Note that `ec.starkCurve.utils.randomPrivateKey()` keeps its name — but prefer
+`stark.randomStarkPrivateKey()`, which returns a `0x`-prefixed hex string instead of bytes.
+
+## Part 2 — Deprecations
+
+Neither of these breaks anything today. Existing code keeps working; migrate at your own pace.
+
+### `stark.randomAddress()`
+
+The name was misleading from the start: the function never returned an address. In v10 it derived a
+Stark **public key** from a random private key, and the guides then used that value as a private
+key. v11 replaces it with two functions that each say what they produce:
+
+- **`stark.randomStarkPrivateKey()`** — a private key of the Stark curve, always 32 bytes, always
+  inside the valid key range.
+- **`stark.randomFelt()`** — a uniformly random felt, for a deployment salt, a SNIP-9 nonce or a
+  test value.
+
+`randomAddress()` is kept as a deprecated alias of `randomFelt()`. Its implementation therefore
+changed — from a curve point's x-coordinate to a uniform draw — but the two remain interchangeable
+in practice, including as a private key: the felt range and the private-key range differ by a
+relative 2.7 × 10⁻³⁸, so a draw falling outside the key range will not happen. Code calling
+`randomAddress()` keeps working exactly as before.
 
 ```typescript
-// For Provider: Use RpcProvider.create() for automatic node version detection
-const myProvider = await RpcProvider.create();
-const myProvider = await RpcProvider.create({ nodeUrl: constants.NetworkName.SN_MAIN });
+const privateKey = stark.randomStarkPrivateKey(); // ✅ was stark.randomAddress()
+const publicKey = ec.starkCurve.getStarkKey(privateKey);
 
-// Or create manually if you know the RPC version
-const myProvider = new RpcProvider({ nodeUrl: '...' });
-
-// For Paymaster: Create a new instance
-const myPaymaster = new PaymasterRpc();
-const myPaymaster = new PaymasterRpc({ nodeUrl: 'https://sepolia.paymaster.avnu.fi' });
-
-// Usage
-const result = await myProvider.getBlock('latest');
-const tokens = await myPaymaster.getSupportedTokens();
+const salt = stark.randomFelt(); // ✅ was stark.randomAddress()
 ```
 
-### Why This Change?
+See [Create an account](./account/create_account.md), which uses the new form throughout.
 
-**Benefits:**
+### `Provider`
 
-- **No implicit global state** - Clearer resource management and easier testing
-- **Auto node detection** - `RpcProvider.create()` automatically detects the node's RPC version
-- **Explicit initialization** - Your code is more transparent about which provider instance you're using
-- **Better contracts** - No hidden provider creation for contracts that don't provide one
-
-### Contract Class Changes
-
-Contracts now auto-initialize a provider on first async method call if none is provided:
+`Provider` is an alias of `RpcProvider`, kept for backward compatibility. It is now marked
+`@deprecated` and will be removed in a future major version. They are the same class, so the
+migration is a rename with no behavior change.
 
 ```typescript
-// v9 - Used global defaultProvider implicitly
-const contract = new Contract({ abi, address });
-const result = await contract.call('balanceOf', [address]); // Used defaultProvider
+import { RpcProvider } from 'starknet'; // ✅ was Provider
 
-// v10 - Still works, but creates provider on first use
-const contract = new Contract({ abi, address });
-const result = await contract.call('balanceOf', [address]); // Creates provider via RpcProvider.create()
-
-// Better: Provide explicit provider
-const provider = await RpcProvider.create({ nodeUrl });
-const contract = new Contract({ abi, address, providerOrAccount: provider });
-const result = await contract.call('balanceOf', [address]);
+const myProvider = new RpcProvider({ nodeUrl: myNodeUrl });
 ```
 
-## Breaking Change 3: Plugin System
+## Part 3 — What is new in v11
 
-### What Changed
+Nothing here requires any change on your side. Each item links to the guide that covers it in full.
 
-The mixin-based extension system using `ts-mixer` has been replaced with a plugin architecture.
+### A provider whose requests and subscriptions share one socket
 
-#### Class Name Changes
-
-**❌ v9 (deprecated):**
+`RpcProvider` over HTTP remains the default. `WebSocketProvider` is the opt-in variant that keeps
+one connection open and uses it for both:
 
 ```typescript
-import { StarknetId, BrotherId } from 'starknet';
+import { WebSocketProvider } from 'starknet';
 
-const name = await StarknetId.getStarkName(provider, address);
-const name2 = await BrotherId.getBrotherName(provider, address);
+const myProvider = new WebSocketProvider({ nodeUrl: 'wss://your-starknet-node/rpc/v0_10' });
+
+const blockNumber = await myProvider.getBlockNumber(); // the usual provider surface
+const sub = await myProvider.subscriptions.subscribeNewHeads(); // plus the subscriptions
+
+myProvider.dispose(); // it holds an open connection: release it
 ```
 
-**✅ v10:**
+It **is** an `RpcProvider`, so `Account` and `Contract` accept it without knowing the difference.
+See [Requests and subscriptions over WebSocket](./provider_instance.md#requests-and-subscriptions-over-websocket),
+and [Choosing HTTP or WebSocket](./provider_instance.md#choosing-http-or-websocket) to decide which
+one your application needs.
+
+### A pluggable transport layer
+
+The object that carries JSON-RPC envelopes to the node is now a separate value implementing
+`RpcTransport`, with three implementations shipped: `HttpTransport`, `WsTransport` and
+`ReconnectingWsTransport`. Any provider or channel accepts a `transport` in place of a `nodeUrl`.
+
+The practical consequence is that one socket can be built once and lent to everything talking to the
+same node — the form to use in React, where the socket lives at module scope and components own only
+their subscriptions:
 
 ```typescript
-import { StarknetIdImpl, BrotherIdImpl } from 'starknet';
+import { ReconnectingWsTransport, WebSocketProvider } from 'starknet';
 
-const name = await StarknetIdImpl.getStarkName(provider, address);
-const name2 = await BrotherIdImpl.getBrotherName(provider, address);
+const transport = new ReconnectingWsTransport({ nodeUrl: 'wss://your-starknet-node/rpc/v0_10' });
+const myProvider = new WebSocketProvider({ transport });
 ```
 
-#### Import Path Changes
+A transport passed in is borrowed, not owned. See [Sharing one socket](./websocket_channel.md#sharing-one-socket).
 
-**❌ v9 (removed):**
+### Two named random generators
 
-```typescript
-import { StarknetId } from 'starknet/provider/extensions/starknetId';
-```
+`stark.randomFelt()` for a salt or a nonce, `stark.randomStarkPrivateKey()` for a key — see
+[`stark.randomAddress()`](#starkrandomaddress) in Part 2.
 
-**✅ v10:**
+### Subscriptions that fit a component lifecycle
 
-```typescript
-import { StarknetIdImpl } from 'starknet';
-// Or, for the plugin factory (see "Disabling or Customizing Plugins" below):
-import { starknetIdPlugin } from 'starknet';
-```
+`Subscription` gains what a React effect needs: `onClose()` to be told when a stream ends on its own
+— including a stream the node refused to restore after a reconnection — and `off()` to detach a
+handler without tearing the subscription down. Re-attaching the same handler with `on()` is now a
+no-op instead of an error, so StrictMode's double invocation no longer fails a correct component.
 
-:::caution
-The StarknetId plugin factory is named **`starknetIdPlugin`**, not `starknetId`: the bare
-`starknetId` name is already taken by the utility namespace (`starknetId.useEncoded`,
-`starknetId.isStarkDomain`, ...), exactly as in v9. The two other factories keep their plain
-names, `brotherId()` and `fastExecute()`.
-:::
+See [When a subscription closes](./websocket_channel.md#when-a-subscription-closes) and
+[In a React app](./websocket_channel.md#in-a-react-app).
 
-### Default Behavior
+### Subscription channels exposed per spec version
 
-**Good news:** For most users, plugins work the same way. The StarknetId, BrotherId and fastExecute plugins are **automatically installed** by default:
-
-```typescript
-// These work out of the box in v10 (no changes needed)
-const provider = new RpcProvider({ nodeUrl });
-await provider.getStarkName(address); // ✅ Works
-
-const account = new Account({ provider, address, signer: privateKey });
-await account.getStarkName(); // ✅ Works
-```
-
-### Disabling or Customizing Plugins
-
-If you want to disable default plugins or use custom ones:
-
-```typescript
-// Disable all plugins
-const provider = new RpcProvider({
-  nodeUrl,
-  plugins: false,
-});
-
-// Use specific plugins only
-import { starknetIdPlugin, brotherId, fastExecute } from 'starknet';
-
-const provider = new RpcProvider({
-  nodeUrl,
-  plugins: [starknetIdPlugin()],
-});
-
-// Add custom plugins
-import { defaultPlugins } from 'starknet';
-
-const provider = new RpcProvider({
-  nodeUrl,
-  plugins: [...defaultPlugins, myCustomPlugin()],
-});
-```
-
-For more details on creating and using plugins, see the [Plugin System Guide](./plugins.md).
-
-## Breaking Change 4: Provider fetch() Method
-
-### What Changed
-
-The `RpcProvider.fetch()` method is now `async`:
-
-**❌ v9:**
-
-```typescript
-// fetch() was synchronous, returned Promise directly
-public fetch(method: string, params?: object) {
-  return this.channel.fetch(method, params);
-}
-```
-
-**✅ v10:**
-
-```typescript
-// fetch() is now async, wraps plugin hooks
-public async fetch(method: string, params?: object) {
-  const hookResult = this.pluginManager.runProviderHook('beforeRequest', { method, params });
-  const result = await this.channel.fetch(finalMethod, finalParams);
-  return this.pluginManager.runProviderHook('afterRequest', { method, params, result }) ?? result;
-}
-```
-
-### Impact
-
-**Low impact** - The method already returned a Promise, so most code using `await provider.fetch()` will continue to work.
-
-**Potential issue:** If you were using `.then()` chains that depended on the exact return type, or catching synchronous errors from `fetch()`, the behavior may differ slightly.
-
-```typescript
-// This still works (no change needed)
-const result = await provider.fetch('starknet_getBlockWithTxHashes', { block_id: 'latest' });
-
-// This also still works
-provider.fetch('starknet_chainId').then((result) => console.log(result));
-```
-
-## Breaking Change 5: Compression Functions Now Async
-
-### What Changed
-
-The `compressProgram()` and `decompressProgram()` functions are now async. This change was made to replace the `pako` dependency with native Compression Streams API (available in Node 17+ and modern browsers), saving ~45KB in bundle size.
-
-**❌ v9:**
-
-```typescript
-import { stark } from 'starknet';
-
-// Synchronous
-const compressed = stark.compressProgram(program);
-const decompressed = stark.decompressProgram(compressed);
-```
-
-**✅ v10:**
-
-```typescript
-import { stark } from 'starknet';
-
-// Now async - must use await
-const compressed = await stark.compressProgram(program);
-const decompressed = await stark.decompressProgram(compressed);
-```
-
-### Impact
-
-**Medium impact** - Only affects code that directly uses these compression utilities.
-
-**Who is affected:**
-
-- Users manually compressing/decompressing Cairo 0 programs
-- Users calling one of the contract-class helpers that internally compress, which became async
-  for the same reason: `parseContract()`, `createSierraContractClass()` and
-  `contractClassResponseToLegacyCompiledContract()`
-- Advanced use cases involving manual contract compilation
-
-**Who is NOT affected:**
-
-- Users only using `account.declare()` and `account.deploy()` - these already handle compression internally and are already async
-
-### Migration
-
-Add `await` to all compression function calls:
-
-```typescript
-// Before (v9)
-function processContract(program) {
-  const compressed = stark.compressProgram(program);
-  return compressed;
-}
-
-// After (v10)
-async function processContract(program) {
-  const compressed = await stark.compressProgram(program);
-  return compressed;
-}
-```
-
-The same applies to the contract-class helpers:
-
-```typescript
-import { provider, contractClassResponseToLegacyCompiledContract } from 'starknet';
-
-// Before (v9)
-const contractClass = provider.parseContract(compiledContract);
-const sierra = provider.createSierraContractClass(compiledSierra);
-const legacy = contractClassResponseToLegacyCompiledContract(response);
-
-// After (v10)
-const contractClass = await provider.parseContract(compiledContract);
-const sierra = await provider.createSierraContractClass(compiledSierra);
-const legacy = await contractClassResponseToLegacyCompiledContract(response);
-```
-
-## Breaking Change 6: SimulateTransaction Response Structure
-
-### What Changed
-
-`SimulateTransactionOverheadResponse` changed from an array to an object. The array is now nested under a `simulated_transactions` property, and a new optional `initial_reads` field is available (RPC 0.10.1+).
-
-**❌ v9:**
-
-```typescript
-const result = await provider.getSimulateTransaction(invocations, options);
-
-// result was an array
-result.forEach((tx) => {
-  console.log(tx.transaction_trace);
-  console.log(tx.overall_fee);
-});
-
-const first = result[0];
-const count = result.length;
-```
-
-**✅ v10:**
-
-```typescript
-const result = await provider.getSimulateTransaction(invocations, options);
-
-// result is now an object with simulated_transactions array
-result.simulated_transactions.forEach((tx) => {
-  console.log(tx.transaction_trace);
-  console.log(tx.overall_fee);
-});
-
-const first = result.simulated_transactions[0];
-const count = result.simulated_transactions.length;
-
-// New: optional initial storage reads (when using returnInitialReads option)
-if (result.initial_reads) {
-  console.log(result.initial_reads);
-}
-```
-
-### Impact
-
-**Medium impact** - Affects all code that uses `getSimulateTransaction()` and iterates over or indexes into the result directly.
-
-### Migration
-
-Replace direct array access with `.simulated_transactions`:
-
-```typescript
-// Before (v9)
-const simResult = await provider.getSimulateTransaction(invocations, options);
-const fee = simResult[0].overall_fee;
-const traces = simResult.map((s) => s.transaction_trace);
-
-// After (v10)
-const simResult = await provider.getSimulateTransaction(invocations, options);
-const fee = simResult.simulated_transactions[0].overall_fee;
-const traces = simResult.simulated_transactions.map((s) => s.transaction_trace);
-```
-
-## Breaking Change 7: ts-mixer Removed
-
-### What Changed
-
-The `ts-mixer` dependency has been completely removed from the library.
-
-**❌ v9:**
-
-- Account used `ts-mixer` to inherit from both custom logic and Provider
-- Extensions used `ts-mixer` to mix in StarknetId and BrotherId
-
-**✅ v10:**
-
-- Account uses composition (has a `provider` property)
-- Extensions use the plugin system
-
-### Migration
-
-If your code didn't directly use `ts-mixer`, no changes are needed. If you were relying on `ts-mixer` behavior:
-
-1. Use the new plugin system for extensions
-2. Access provider methods via `account.provider`
-3. If you depended on `ts-mixer` as a transitive dependency, add it directly to your `package.json`
-
-## Breaking Change 8: getStorageAt() Return Type
-
-### What Changed
-
-The `getStorageAt()` method now returns a `STORAGE_RESULT` object instead of a plain string. The
-response type exported by the library was renamed accordingly: `Storage` → `StorageResponse`.
-
-**❌ v9:**
-
-```typescript
-const value = await provider.getStorageAt(address, key);
-const felt = BigInt(value); // ✗ Error: value is now an object
-```
-
-**✅ v10:**
-
-```typescript
-const result = await provider.getStorageAt(address, key);
-const felt = BigInt(result.value); // ✓ Access .value property
-
-// Result structure:
-// {
-//   value: string (FELT),
-//   last_update_block: number
-// }
-```
-
-### Why This Change?
-
-The RPC spec 0.10.1 now supports optional metadata with storage responses, allowing you to get the block number when the storage was last modified.
-
-### Migration Guide
-
-Replace direct usage with `.value` property access:
-
-```typescript
-// Before:
-const storage = await provider.getStorageAt(addr, key);
-const felt = BigInt(storage);
-
-// After:
-const storage = await provider.getStorageAt(addr, key);
-const felt = BigInt(storage.value);
-
-// Or destructure if you need the metadata:
-const { value, last_update_block } = await provider.getStorageAt(addr, key);
-const felt = BigInt(value);
-```
-
-If you imported the response type, rename it:
-
-```typescript
-import type { StorageResponse } from 'starknet'; // ✅ Was `Storage`
-```
-
-## Breaking Change 9: fastExecute Is Now a Plugin
-
-### What Changed
-
-In v9, `fastExecute()` was a native `Account` method and `fastWaitForTransaction()` a native
-`RpcProvider` method. In v10 both come from the `fastExecute` plugin, which is part of
-`defaultPlugins`.
-
-**Good news:** with the default configuration, nothing changes:
-
-```typescript
-// Still works out of the box in v10
-const resp = await account.fastExecute(call, { tip }, { retries: 30, retryInterval: 500 });
-```
-
-**❌ Breaks if you opted out of plugins:**
-
-```typescript
-const account = new Account({ provider, address, signer, plugins: false });
-await account.fastExecute(call); // ✗ Method does not exist anymore
-```
-
-Re-add the plugin explicitly when you disable the defaults:
-
-```typescript
-import { fastExecute } from 'starknet';
-
-const account = new Account({ provider, address, signer, plugins: [fastExecute()] });
-```
-
-### Type Renames
-
-The two related types were renamed to follow the naming convention:
-
-```typescript
-import type { FastExecuteResponse } from 'starknet'; // ✅ Was fastExecuteResponse
-import type { FastWaitForTransactionOptions } from 'starknet'; // ✅ Was fastWaitForTransactionOptions
-```
-
-Method signatures are unchanged.
-
-## Breaking Change 10: Paymaster `default` Option Renamed
-
-### What Changed
-
-`PaymasterRpcOptions.default` was renamed to `mute`. It silences the informational message emitted
-when a `PaymasterRpc` falls back to its default node URL.
-
-**❌ v9:**
-
-```typescript
-const myPaymaster = new PaymasterRpc({ default: true });
-```
-
-**✅ v10:**
-
-```typescript
-const myPaymaster = new PaymasterRpc({ mute: true });
-```
-
-Note that `RpcProviderOptions.default` was removed entirely (it only served the deleted
-`defaultProvider` singleton) and has no replacement.
-
-## Breaking Change 11: felt252 Range Validation
-
-### What Changed
-
-`CairoFelt()` now validates that the value fits in the felt252 range `[0, P)` and throws otherwise.
-In v9, an out-of-range value was silently converted and sent to the network.
-
-```typescript
-// v9: accepted silently
-// v10: throws `Value ... is out of felt252 range [0, ...)`
-CairoFelt(2n ** 252n);
-```
-
-In addition, `CairoFelt252.toApiRequest()` now returns the **decimal** string representation instead
-of the hexadecimal one, which aligns it with the rest of the compiled calldata:
-
-```typescript
-new CairoFelt252(1000n).toApiRequest(); // v9: ['0x3e8'] → v10: ['1000']
-```
-
-### Impact
-
-**Low** for normal use: `CallData.compile()` and contract calls behave the same, since the network
-receives equivalent values. It only affects code that compares compiled calldata to hard-coded
-strings, or that relied on out-of-range values not throwing.
-
-## Breaking Change 12: RPC Namespace Renames
-
-Two public exports were renamed to track the new default RPC spec version. These only affect advanced usage (raw RPC spec types and direct channel imports).
-
-### `RPCSPEC010` → `RPCSPEC0103`
-
-The namespace re-exporting the 0.10.x RPC spec types was renamed.
-
-**❌ v9:**
-
-```typescript
-import { RPCSPEC010 } from 'starknet';
-
-type MyBlock = RPCSPEC010.BLOCK_WITH_TXS;
-```
-
-**✅ v10:**
-
-```typescript
-import { RPCSPEC0103 } from 'starknet';
-
-type MyBlock = RPCSPEC0103.BLOCK_WITH_TXS;
-```
-
-### `RPC010` → `RPC0102` / `RPC0103`
-
-The channel namespace for the 0.10.x RPC implementation was renamed. v10 exposes two channel variants: `RPC0102` (spec 0.10.2) and `RPC0103` (spec 0.10.3, the default).
-
-**❌ v9:**
-
-```typescript
-import { RPC010 } from 'starknet';
-```
-
-**✅ v10:**
-
-```typescript
-import { RPC0103 } from 'starknet'; // spec 0.10.3 (default)
-import { RPC0102 } from 'starknet'; // spec 0.10.2 (legacy)
-```
-
-:::note
-Standard usage via `RpcProvider`, `Account`, and high-level methods is unaffected by these renames.
-:::
-
-## Other Minor Changes
-
-- `getBlock()` called without argument is now typed `Promise<Block>` instead of
-  `Promise<PreConfirmedBlock>`. The runtime behavior is unchanged — it returns the block designated
-  by the provider `blockIdentifier` option — but code that accessed pre-confirmed-only fields on the
-  result no longer type-checks. Use `getBlock('pre_confirmed')` for the pre-confirmed block.
-- `pako` is no longer a dependency (replaced by the native Compression Streams API), alongside the
-  removal of `ts-mixer`.
-
-## Migration Checklist
-
-When upgrading from v9 to v10:
-
-- [ ] Update `starknet` package to v10.x
-- [ ] **Account Composition:**
-  - [ ] Find all `account.xyz()` calls where `xyz` is a provider method
-  - [ ] Replace with `account.provider.xyz()`
-  - [ ] Verify account-specific methods (`execute`, `signMessage`, etc.) still work directly
-- [ ] **Plugin System:**
-  - [ ] Update plugin imports: `StarknetId` → `StarknetIdImpl` (if importing directly)
-  - [ ] Update plugin imports: `BrotherId` → `BrotherIdImpl` (if importing directly)
-  - [ ] Update import paths: `starknet/provider/extensions/` → package root (`'starknet'`)
-  - [ ] Use `starknetIdPlugin()` for the plugin factory, not `starknetId()`
-  - [ ] Test that plugin methods still work: `getStarkName()`, `getAddressFromStarkName()`, etc.
-  - [ ] If using `plugins: false`, verify this is intentional (disables StarknetId/BrotherId/fastExecute)
-- [ ] **fastExecute:**
-  - [ ] Rename the types: `fastExecuteResponse` → `FastExecuteResponse`, `fastWaitForTransactionOptions` → `FastWaitForTransactionOptions`
-  - [ ] If you disabled the default plugins, add `fastExecute()` back to keep `account.fastExecute()` and `provider.fastWaitForTransaction()`
-- [ ] **Compression Functions:**
-  - [ ] Search for `compressProgram()` calls and add `await`
-  - [ ] Search for `decompressProgram()` calls and add `await`
-  - [ ] Search for `parseContract()`, `createSierraContractClass()` and `contractClassResponseToLegacyCompiledContract()` calls and add `await`
-  - [ ] Make calling functions `async` if they weren't already
-- [ ] **Provider Changes:**
-  - [ ] Review any code using `provider.fetch()` with `.then()` chains
-  - [ ] Verify error handling still works correctly
-- [ ] **Storage Queries:**
-  - [ ] Find all `getStorageAt()` calls
-  - [ ] Update usage from `BigInt(result)` to `BigInt(result.value)`
-  - [ ] Rename the imported type `Storage` → `StorageResponse`
-  - [ ] Optionally use `result.last_update_block` if you need metadata
-- [ ] **Paymaster:**
-  - [ ] Rename the `default` option to `mute` in `new PaymasterRpc({ ... })`
-- [ ] **Cairo Types:**
-  - [ ] Check that no felt252 value you build is outside `[0, P)` — it now throws instead of being silently converted
-  - [ ] If you compare compiled calldata to hard-coded strings, note that `CairoFelt252.toApiRequest()` returns decimal, not hex
-- [ ] **SimulateTransaction Response:**
-  - [ ] Find all `getSimulateTransaction()` calls
-  - [ ] Replace direct array access (e.g., `result[0]`, `result.map()`) with `result.simulated_transactions[0]`, `result.simulated_transactions.map()`
-  - [ ] Optionally use `result.initial_reads` if using `returnInitialReads` option
-- [ ] **Dependencies:**
-  - [ ] Remove any references to `ts-mixer` if you were using it
-  - [ ] If you depended on `ts-mixer` or `pako` transitively, add them to your `package.json`
-- [ ] **Custom Extensions:**
-  - [ ] If you created custom extensions, migrate them to the plugin system (see [Plugin Guide](./plugins.md))
-- [ ] **Testing:**
-  - [ ] Run your test suite to catch any missed migrations
-  - [ ] Verify all provider method calls work with `account.provider.xyz()`
-  - [ ] Test plugin functionality (StarknetId, BrotherId)
-
-## New in v10: Transaction `proof` and `proofFacts` Fields
-
-v9 had no transaction proof at all. v10 adds two optional fields to the v3 transaction details,
-following RPC 0.10.1+: `proof` and `proofFacts`. Nothing to migrate — this section only describes
-how to use them.
-
-The `proof` field is typed as a `string`: a base64 encoding of big-endian packed `u32` values.
-Use `stark.encodeProof()` to build it from a number array:
-
-```typescript
-import { stark } from 'starknet';
-
-// Step 1: encode the array to base64
-const proofBase64 = stark.encodeProof([1, 2, 3, 4]);
-// result = "AQAAAAIAAAADAAAABAAAAA=="
-
-// Step 2: pass the encoded string
-await account.execute(calls, {
-  proof: proofBase64, // must be a base64 string
-});
-```
-
-The same option is accepted by the other Account methods:
-
-```typescript
-await account.estimateInvokeFee(calls, { proof: proofBase64 });
-await account.simulateTransaction(invocations, { proof: proofBase64 });
-```
-
-Decode it back if needed:
-
-```typescript
-const proofArray = stark.decodeProof(proofBase64);
-```
-
-### The `proofFacts` Field
-
-`proofFacts` is an optional companion to `proof`. When present, it changes the v3 transaction hash computation (the Poseidon of all proof facts is folded into the hash).
-
-```typescript
-// proofFacts is optional — pass only when your SNIP-36 off-chain computation
-// produces facts that must be committed on-chain
-await account.execute(calls, {
-  proof: proofBase64, // base64-encoded proof (see above)
-  proofFacts: [fact1, fact2], // BigNumberish[] — omit if unused
-});
-```
-
-:::note
-Both fields are optional: code that never sets them behaves exactly as before. Set them only when
-your use case requires SNIP-36 fact commitment — see the [Proofs (SNIP-36) guide](./account/proofs.md).
-:::
-
-## What Else Is New in v10
-
-None of the following requires any migration work, but they are worth knowing about once you are on
-v10:
-
-- **RPC 0.10.3 support.** Two channels ship side by side, `RPC0102` (spec 0.10.2) and `RPC0103`
-  (spec 0.10.3, the default). `RpcProvider.create()` picks the right one from the node.
-- **Runtime plugin installation** with `provider.use(plugin)`, fully typed — see the
-  [Plugin System Guide](./plugins.md).
-- **`contract.compile(method, args)`** returns the compiled `Calldata` alone, without the
-  `Invocation` wrapper produced by `populate()`.
-- **`account.getSignedTransaction()` / `provider.invokeSignedTx()`** to split signing and
-  broadcasting into two steps.
-- **`WalletAccountV6`** and the `walletV6` namespace: wallet-standard connection
-  (`standardConnect()`), STRK20 privacy methods (`strk20Balances`, `strk20PrepareInvoke`,
-  `strk20InvokeTransaction`, `strk20ShadowAccountCommitment`) and shadow accounts — see the
-  [WalletAccount guide](./account/walletAccount.md).
-- **Initial storage reads:** pass `returnInitialReads: true` to `getSimulateTransaction()` or
-  `getBlockTransactionsTraces()` to get an `initial_reads` field back, and
-  `getTransaction(txHash, { includeProofFacts: true })` to get the proof facts of a transaction.
-- **WebSocket subscriptions:** `fromAddress` now accepts an array of addresses, transaction
-  subscriptions accept `tags`, and reconnection accepts a `stableConnectionThreshold` option — see
-  the [WebSocket guide](./websocket_channel.md).
-- **WebSocket transport:** `WebSocketProvider` serves requests and subscriptions from a single
-  socket, and the socket itself is now a separate object that several providers can share — see
-  [Requests and subscriptions over WebSocket](./provider_instance.md#requests-and-subscriptions-over-websocket).
-- **`walletAccount.onChange()`** now returns an unsubscribe function.
+`src/channel/` is reorganized into per-version directories, and the `RPC09`, `RPC0102` and `RPC0103`
+namespaces now export a `SubscriptionChannel` alongside their `RpcChannel`. Pairing the two of the
+same version is what makes a version mismatch between requests and subscriptions impossible.
 
 ## Need Help?
 
-- Check the [Plugin System Guide](./plugins.md) for details on how plugins work
-- Review the [examples](https://github.com/starknet-io/starknet.js/tree/develop/examples) in the repository
-- Ask questions in [GitHub Discussions](https://github.com/starknet-io/starknet.js/discussions)
+Ask your questions on the
+[Starknet.js Discord channel](https://discord.com/channels/793094838509764618/1270119831559078061),
+in the [Starknet Discord](https://discord.com/invite/starknet-community).


### PR DESCRIPTION
## Motivation and Resolution

`www/docs/guides/migrate.md` still documented the v9 → v10 migration, which is of no use to anyone
landing on `11.0.0-beta.1`. The guide is rewritten from scratch for v10 (10.7.0) → v11; the old
content is dropped rather than archived, since it remains available in the history of the docs.

The inventory was derived from `git diff v10.7.0..HEAD` and from the description of #1672, then
every claim was checked against the code — which turned up two inaccuracies in that description
that the guide deliberately contradicts:

1. **`stark.randomAddress()` does not stop returning a usable key.** In v10 it returned
   `getStarkKey(randomPrivateKey())` — a *public* key, which the guides then used as a private key.
   In v11 it aliases `randomFelt()`. Over 5000 draws of each, both land inside the private-key
   range every time: `PRIME` and the curve order differ by a relative 2.7 × 10⁻³⁸. Nothing breaks,
   so this is filed as a deprecation, not a breaking change.
2. **`sig instanceof Signature` still works.** `@scure/starknet` 2.3 still exports `Signature` and
   `sign()` still returns an instance of it. What disappeared is the `Signature` export of
   `@noble/curves/abstract/weierstrass.js`, which is a different thing — and
   `WeierstrassSignatureType` has always been a *type*, so `instanceof` never applied to it.

The result is 4 breaking changes rather than 6, plus 2 deprecations that break nothing today.

### RPC version (if applicable)

Not applicable — documentation only, no spec version is involved.

## Usage related changes

- **`migrate.md` rewritten for v10 → v11**, in three parts:
  - *Part 1 — Breaking changes*, ordered by how likely a reader is to hit them: Node >= 22.12
    (`ERR_REQUIRE_ESM` on 22.0–22.11), the Jest `transformIgnorePatterns` the ESM-only crypto
    packages now require (`SyntaxError: Unexpected token 'export'`), the encoding methods lost by
    signature objects (`toDERHex()` → `toHex('der')` and its three siblings), and the moved
    `@noble` / `@scure` import paths.
  - *Part 2 — Deprecations*: `stark.randomAddress()` and `Provider`, both stated as breaking
    nothing.
  - *Part 3 — What is new in v11*: `WebSocketProvider`, the pluggable transport layer,
    `randomFelt()` / `randomStarkPrivateKey()`, the `Subscription` lifecycle additions, and the
    per-version subscription channels — each linking to the guide that covers it in full rather
    than duplicating it.
- A **"What did not change"** section, worth stating on a major: `Account`, `Contract`, `CallData`,
  the Cairo helpers and `SignerInterface` are untouched, `WebSocketChannel` keeps the exact API it
  had in v10, no RPC spec is added or dropped, and no export was removed.
- **Questions now point to Discord** instead of GitHub Discussions. The old "Need Help?" section
  also linked to `starknet-io/starknet.js/tree/develop/examples`, which returns 404 and matches no
  directory on `develop` — removed.
- **`signature.md`**: `stark` added to the import list although it is used twice in the file, and
  `rpcProvider.verifyMessageInStarknet(…)` corrected to `await myProvider.…` — the variable is
  declared as `myProvider` two lines above, and the call is typed `Boolean` but was not awaited.
- **`configuration.md`**: the `config.set('websocket', …)` comment no longer refers to a Node
  version below the supported floor.

## Development related changes

None — documentation only, no source file is touched.

For the record, the guide's snippets were verified rather than proof-read:

- Every crypto snippet of `signature.md` was executed against the v11 build — `getStarkKey`,
  `getFullPublicKey`, `sign`, `starkCurve.verify` with a full public key, the three
  `typedData.verifyMessage` forms, the `slice(4, 68)` identity, and the whole SNIP-12 flow. All
  pass. `EthSigner.getPubKey()` was cross-checked against a secp256k1 reference computed
  independently: identical.
- The typed snippets were then compiled with the project's own `tsconfig.json` (`strict: true`)
  against `src/`. `WeierstrassSignatureType` is still assignable from `ec.starkCurve.sign()`, and
  the cast in the SNIP-12 section still holds.
- Every relative link and anchor in `migrate.md` resolves to an existing heading.

Two pre-existing defects in `signature.md` were found this way and are **not** fixed here, as
neither stems from the crypto bump:

- line 68: `ec.starkCurve.verify(signature1, …)` — `signature1` is never declared; the variable is
  `signature`.
- line 224: `myEthSigner.signMessage(message, …)` passes the `BigNumberish[]` declared line 21,
  while `EthSigner.signMessage` takes a `TypedData` — the only type error the compiler reports on
  the whole guide. The method signature is unchanged since v10.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes in code (API docs will be generated automatically)
