### PR TITLE
Remove deprecated ReceiptTx

### DIFF
--- a/__tests__/contract.test.ts
+++ b/__tests__/contract.test.ts
@@ -15,7 +15,6 @@ import {
   num,
   byteArray,
   RpcError,
-  ReceiptTx,
   RpcProvider,
   contractLoader,
 } from '../src';
@@ -1116,7 +1115,7 @@ describe('Complex interaction', () => {
 
       const result4 = await echoContract.invoke('iecho', args, { waitForTransaction: true });
       expect(result4.block_number).toBeDefined();
-      expect(result4).toBeInstanceOf(ReceiptTx);
+      expect(result4.statusReceipt).toBe('SUCCEEDED');
       expect(result4.isSuccess()).toBe(true);
 
       const result5 = await echoContract.withOptions({ waitForTransaction: true }).iecho(calldata);

--- a/__tests__/rpcProvider.test.ts
+++ b/__tests__/rpcProvider.test.ts
@@ -22,7 +22,6 @@ import {
   ProviderInterface,
   RPC,
   RPCResponseParser,
-  ReceiptTx,
   RpcProvider,
   TransactionExecutionStatus,
   cairo,
@@ -288,12 +287,18 @@ describe('RPCProvider', () => {
 
     test('successful - default', async () => {
       transactionStatusSpy.mockResolvedValueOnce(response.successful);
-      await expect(rpcProvider.waitForTransaction(0)).resolves.toBeInstanceOf(ReceiptTx);
+      transactionReceiptSpy.mockResolvedValueOnce({ execution_status: 'SUCCEEDED' });
+      await expect(rpcProvider.waitForTransaction(0)).resolves.toMatchObject({
+        statusReceipt: 'SUCCEEDED',
+      });
     });
 
     test('reverted - default', async () => {
       transactionStatusSpy.mockResolvedValueOnce(response.reverted);
-      await expect(rpcProvider.waitForTransaction(0)).resolves.toBeInstanceOf(ReceiptTx);
+      transactionReceiptSpy.mockResolvedValueOnce({ execution_status: 'REVERTED' });
+      await expect(rpcProvider.waitForTransaction(0)).resolves.toMatchObject({
+        statusReceipt: 'REVERTED',
+      });
     });
 
     test('reverted - as error state', async () => {

--- a/src/provider/types/spec.type.ts
+++ b/src/provider/types/spec.type.ts
@@ -80,27 +80,6 @@ export type PRE_CONFIRMED_STATE_UPDATE = Merge<
   RPCSPEC0103.PRE_CONFIRMED_STATE_UPDATE,
   RPCSPEC09.PRE_CONFIRMED_STATE_UPDATE
 >;
-// TODO: Can we remove all of this ?
-/* export type INVOKE_TXN_RECEIPT = IsInBlock<RPCSPEC08.IsType<RPCSPEC08.TransactionReceipt, 'INVOKE'>>;
-export type DECLARE_TXN_RECEIPT = IsInBlock<RPCSPEC08.IsType<RPCSPEC08.TransactionReceipt, 'DECLARE'>>;
-export type DEPLOY_ACCOUNT_TXN_RECEIPT = IsInBlock<
-  RPCSPEC08.IsType<RPCSPEC08.TransactionReceipt, 'DEPLOY_ACCOUNT'>
->;
-export type L1_HANDLER_TXN_RECEIPT = IsInBlock<RPCSPEC08.IsType<RPCSPEC08.TransactionReceipt, 'L1_HANDLER'>>; */
-
-/* export type PENDING_INVOKE_TXN_RECEIPT = RPCSPEC08.IsPending<
-  RPCSPEC08.IsType<RPCSPEC08.TransactionReceipt, 'INVOKE'>
->;
-export type PENDING_DECLARE_TXN_RECEIPT = RPCSPEC08.IsPending<
-  RPCSPEC08.IsType<RPCSPEC08.TransactionReceipt, 'DECLARE'>
->;
-export type PENDING_DEPLOY_ACCOUNT_TXN_RECEIPT = RPCSPEC08.IsPending<
-  RPCSPEC08.IsType<RPCSPEC08.TransactionReceipt, 'DEPLOY_ACCOUNT'>
->;
-export type PENDING_L1_HANDLER_TXN_RECEIPT = RPCSPEC08.IsPending<
-  RPCSPEC08.IsType<RPCSPEC08.TransactionReceipt, 'L1_HANDLER'>
->; */
-//
 
 export type BlockWithTxHashes = Merge<RPCSPEC0103.BlockWithTxHashes, RPCSPEC09.BlockWithTxHashes>;
 export type ContractClassPayload = Merge<RPCSPEC0103.ContractClass, RPCSPEC09.ContractClass>;

--- a/src/utils/transactionReceipt/transactionReceipt.ts
+++ b/src/utils/transactionReceipt/transactionReceipt.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import {
   GetTxReceiptResponseWithoutHelper,
   RevertedTransactionReceiptResponse,
@@ -12,118 +11,16 @@ import type {
   ErrorReceiptResponseHelper,
   TransactionReceiptCallbacks,
   TransactionReceiptCallbacksDefault,
-  TransactionReceiptStatus,
-  TransactionReceiptValue,
 } from './transactionReceipt.type';
 
 /**
  * !! Main design decision:
  * Class can't extend GetTransactionReceiptResponse because it is union type
  * and it is not possible to extend union type in current typescript version
- * So we have to use factory function to create 'data' return type and inject constructor
+ * So we have to use factory function to create 'data' return type
  *
  * ERROR case left but in library flow it is not possible as fetch would throw on error before it could be read by Helper
  */
-
-/**
- * @deprecated Use `createTransactionReceipt` instead
- * Utility that analyses transaction receipt response and provides helpers to process it
- * @example
- * ```typescript
- * const responseTx = new ReceiptTx(receipt);
- * responseTx.match({
- *   success: (txR: SuccessfulTransactionReceiptResponse) => { },
- *   reverted: (txR: RevertedTransactionReceiptResponse) => { },
- *   error: (err: Error) => { },
- * });
- * responseTx.match({
- *   success: (txR: SuccessfulTransactionReceiptResponse) => { },
- *   _: () => { },
- * }
- * ```
- */
-// Legacy class for backward compatibility (defined first for prototype hack)
-export class ReceiptTx {
-  public readonly statusReceipt!: TransactionReceiptStatus;
-
-  public readonly value!: TransactionReceiptValue;
-
-  constructor(receipt: GetTxReceiptResponseWithoutHelper) {
-    // Copy all receipt properties to this instance
-    Object.assign(this, receipt);
-
-    // Determine status and value
-    const [statusReceipt, value] = ReceiptTx.isSuccess(receipt)
-      ? ['SUCCEEDED', receipt]
-      : ReceiptTx.isReverted(receipt)
-        ? ['REVERTED', receipt]
-        : ['ERROR', new Error('Unknown response type')];
-
-    // Define statusReceipt and value as non-enumerable properties
-    Object.defineProperties(this, {
-      statusReceipt: {
-        value: statusReceipt,
-        writable: false,
-        enumerable: false,
-        configurable: false,
-      },
-      value: {
-        value,
-        writable: false,
-        enumerable: false,
-        configurable: false,
-      },
-      match: {
-        value(callbacks: TransactionReceiptCallbacks) {
-          return statusReceipt in callbacks
-            ? (callbacks as any)[statusReceipt]!(value)
-            : (callbacks as TransactionReceiptCallbacksDefault)._();
-        },
-        writable: false,
-        enumerable: false,
-        configurable: false,
-      },
-      isSuccess: {
-        value: () => statusReceipt === 'SUCCEEDED',
-        writable: false,
-        enumerable: false,
-        configurable: false,
-      },
-      isReverted: {
-        value: () => statusReceipt === 'REVERTED',
-        writable: false,
-        enumerable: false,
-        configurable: false,
-      },
-      isError: {
-        value: () => statusReceipt === 'ERROR',
-        writable: false,
-        enumerable: false,
-        configurable: false,
-      },
-    });
-  }
-
-  match!: (callbacks: TransactionReceiptCallbacks) => void;
-
-  isSuccess!: () => this is SuccessfulTransactionReceiptResponseHelper;
-
-  isReverted!: () => this is RevertedTransactionReceiptResponseHelper;
-
-  isError!: () => this is ErrorReceiptResponseHelper;
-
-  static isSuccess(
-    transactionReceipt: GetTxReceiptResponseWithoutHelper
-  ): transactionReceipt is SuccessfulTransactionReceiptResponse {
-    return transactionReceipt.execution_status === TransactionExecutionStatus.SUCCEEDED;
-  }
-
-  static isReverted(
-    transactionReceipt: GetTxReceiptResponseWithoutHelper
-  ): transactionReceipt is RevertedTransactionReceiptResponse {
-    return transactionReceipt.execution_status === TransactionExecutionStatus.REVERTED;
-  }
-}
 
 // Receipt configuration mapping - data-driven approach
 const RECEIPT_CONFIG = {
@@ -204,15 +101,6 @@ export function createTransactionReceipt(
       },
     };
   }
-
-  // 🔥 HACK: Make it look like ReceiptTx instance for instanceof checks
-  Object.setPrototypeOf(obj, ReceiptTx.prototype);
-  Object.defineProperty(obj, 'constructor', {
-    value: ReceiptTx,
-    writable: false,
-    enumerable: false,
-    configurable: false,
-  });
 
   return obj as GetTransactionReceiptResponse;
 }

--- a/www/docs/guides/migrate.md
+++ b/www/docs/guides/migrate.md
@@ -28,6 +28,7 @@ v8.2.0 are finally removed.
 | Signature objects lost their v1 encoding methods  | **Medium** | Rename `toDERHex()` and its three siblings     |
 | `CairoFelt()` and `encode.utf8ToArray()` removed  | **Low**    | Rename to `CairoFelt252` / `utf8ToUint8Array`  |
 | `@noble` / `@scure` import paths changed          | **Low**    | Only if you import these packages directly     |
+| The `ReceiptTx` class removed                     | **Low**    | Only if you used `instanceof ReceiptTx`        |
 
 Two deprecations ship with the release — `stark.randomAddress()` and `Provider` — but neither of
 them breaks existing code. They are covered in [Part 2](#part-2--deprecations).
@@ -268,6 +269,24 @@ const key = secp256k1.utils.randomSecretKey(); // ✅ was randomPrivateKey()
 
 Note that `ec.starkCurve.utils.randomPrivateKey()` keeps its name — but prefer
 `stark.randomStarkPrivateKey()`, which returns a `0x`-prefixed hex string instead of bytes.
+
+### 7. The `ReceiptTx` class is removed
+
+`ReceiptTx` was marked `@deprecated` in v6.24.0 (February 2025) in favour of the
+`createTransactionReceipt()` factory, and survived v7, v8, v9 and v10. It is now gone.
+
+Receipts themselves do not change: `getTransactionReceipt()` and `waitForTransaction()` already
+returned the factory's object, with the same properties and the same helpers. Only code naming the
+class breaks — `new ReceiptTx()`, which the library never used internally, and `instanceof`:
+
+```typescript
+const receipt = await provider.waitForTransaction(transaction_hash);
+
+receipt.isSuccess(); // the helpers are unchanged
+receipt.statusReceipt; // ✅ 'SUCCEEDED' | 'REVERTED' | 'ERROR', replaces `instanceof ReceiptTx`
+```
+
+The `TransactionReceiptStatus` and `TransactionReceiptValue` types are unaffected.
 
 ## Part 2 — Deprecations
 


### PR DESCRIPTION
## Motivation and Resolution

`ReceiptTx` was marked `@deprecated` in v6.24.0 (February 2025) in favour of the
`createTransactionReceipt()` factory, and went through v7, v8, v9 and v10 untouched — four major
versions. v11 is the release where the deprecated surface goes away, as already done for the string
helpers in #1674.

The class had no remaining role. `createTransactionReceipt()` has been the only real code path for a
while: `RpcProvider.getTransactionReceipt()` and `RpcProvider.waitForTransaction()` both call the
factory, and nothing in the library ever calls `new ReceiptTx()`. The class was kept alive only by a
prototype hack at the end of the factory — `Object.setPrototypeOf(obj, ReceiptTx.prototype)` plus a
non-writable `constructor` redefinition, applied to *every* receipt the library returns — whose sole
purpose was to keep a user-side `instanceof ReceiptTx` test passing. Removing the class removes the
hack: the factory now returns a plain object literal.

Two side cleanups come with it:

- `src/provider/types/spec.type.ts` carried a `// TODO: Can we remove all of this ?` followed by 20
  lines of commented-out receipt types. The answer is yes: they reference `RPCSPEC08`, which is not
  even imported in that file. Dead text since spec 0.8 was dropped.
- The `/* eslint-disable no-nested-ternary */` at the top of `transactionReceipt.ts` is gone — the
  nested ternary it covered was in the removed constructor.

While adapting the tests, the `instanceof` assertions turned out to be vacuous. In
`rpcProvider.test.ts`, the `waitForTransaction` fixture is `const receipt = {}`: only the transaction
*status* was mocked, never the *receipt*, so the returned object always fell into the `ERROR` branch
of `createTransactionReceipt()`. `toBeInstanceOf(ReceiptTx)` passed regardless, because the prototype
hack applied to all three branches including `ERROR` — so `successful - default` and
`reverted - default` asserted the opposite of what their names claim. Both now mock the receipt with
the matching `execution_status` and assert `statusReceipt`.

### RPC version (if applicable)

Not applicable — no RPC spec change. 0.9 and 0.10.x remain supported, 0.10.3 stays the default.

## Usage related changes

- `ReceiptTx` is no longer exported from the package. Only code naming the class breaks:
  `new ReceiptTx()` and `instanceof ReceiptTx`.
- Receipt objects themselves are unchanged. `getTransactionReceipt()` and `waitForTransaction()`
  already returned the factory's object, with the same properties and the same `match()` /
  `isSuccess()` / `isReverted()` / `isError()` helpers. An `instanceof` test is replaced by reading
  `receipt.statusReceipt` (`'SUCCEEDED' | 'REVERTED' | 'ERROR'`) or by calling the helpers.
- The `TransactionReceiptStatus` and `TransactionReceiptValue` types are unaffected and stay
  exported.
- The v10 → v11 migration guide gets a new section 7 and a matching row in its summary table.

## Development related changes

- `createTransactionReceipt()` no longer patches the prototype and the constructor of every receipt
  it builds; `transactionReceipt.ts` drops from 219 to 104 lines.
- Two previously vacuous `waitForTransaction` tests now verify the success and reverted paths.
- 20 lines of dead commented-out `RPCSPEC08` types removed from `spec.type.ts`.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
