### PR TITLE
ci(release): make semantic-release understand the ! breaking-change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ on:
       - 'src/**'
       - 'package*'
       - 'ts*'
+      # a change to the release configuration must be able to run the release
+      - '.releaserc*'
       - '!www/**'
   push:
     branches:
@@ -35,6 +37,8 @@ on:
       - 'src/**'
       - 'package*'
       - 'ts*'
+      # a change to the release configuration must be able to run the release
+      - '.releaserc*'
       - '!www/**'
 
 # Cancel redundant in-progress runs for the same ref (replaces the

--- a/.releaserc.mjs
+++ b/.releaserc.mjs
@@ -1,5 +1,19 @@
 /* eslint-disable no-template-curly-in-string */
 /**
+ * The default `angular` preset predates the `!` breaking-change marker: its
+ * `headerPattern` has no `!?` before the colon, so `feat(scope)!: subject` does not
+ * parse at all. The commit is then read as having no type, matches no release rule
+ * and triggers no release — silently, because commitlint accepts the form. These
+ * options add the marker back, and must be passed to the notes generator too:
+ * without them there the release happens with an empty changelog entry.
+ */
+const parserOpts = {
+  headerPattern: /^(\w*)(?:\((.*)\))?!?: (.*)$/,
+  headerCorrespondence: ['type', 'scope', 'subject'],
+  breakingHeaderPattern: /^(\w*)(?:\((.*)\))?!: (.*)$/,
+};
+
+/**
  * @type {import('semantic-release').GlobalConfig}
  */
 export default {
@@ -23,8 +37,8 @@ export default {
     },
   ],
   plugins: [
-    '@semantic-release/commit-analyzer',
-    '@semantic-release/release-notes-generator',
+    ['@semantic-release/commit-analyzer', { parserOpts }],
+    ['@semantic-release/release-notes-generator', { parserOpts }],
     '@semantic-release/changelog',
     '@semantic-release/npm',
     [


### PR DESCRIPTION
## Motivation and Resolution

`feat(receipt)!: remove the deprecated ReceiptTx class` (#1675) was merged into `beta` and published nothing. The Release workflow ran and reported success; semantic-release simply found nothing to
release:

```
Found git tag v11.0.0-beta.2 associated with version 11.0.0-beta.2 on branch beta
Found 2 commits since last release
Analyzing commit: feat(receipt)!: remove the deprecated ReceiptTx class
The commit should not trigger a release
Analysis of 2 commits complete: no release
```

`.releaserc.mjs` declares `@semantic-release/commit-analyzer` with no preset, so it falls back to
`angular`. That preset predates the `!` breaking-change marker — `conventional-changelog-angular@8`
parses headers with:

```js
headerPattern: /^(\w*)(?:\((.*)\))?: (.*)$/,
noteKeywords: ['BREAKING CHANGE'],
```

There is no `!?` before the colon and no `breakingHeaderPattern`. `feat(scope)!: subject` therefore
fails to match **entirely**: the commit is read as having no type at all, so neither
`{type: 'feat'} → minor` nor `{breaking: true} → major` applies. The `!` does not downgrade a commit,
it makes it invisible.

The failure is silent because `@commitlint/config-conventional` accepts the form — it is valid
Conventional Commits. Only semantic-release, pinned to an older preset, disagrees. The two `!`
commits that did release (`feat!: starknet.js v11`, `feat(cairo)!: remove the deprecated string
helpers`) were carried by their `BREAKING CHANGE:` footer, not by the marker.

**Resolution:** override `parserOpts` on the analyzer so the marker parses, and pass the same object
to the release-notes generator — without it the release goes out with an empty changelog entry. No
preset swap, so no new dependency and no change to how the changelog renders.

`.releaserc*` is also added to the `paths` filters of this workflow: a change to the release
configuration could not previously trigger the release workflow, so this fix would not have applied
itself on merge.

### RPC version (if applicable)

Not applicable.

## Usage related changes

- No library code is touched; the public API is unchanged.
- On merge, the release blocked since #1675 is published as `11.0.0-beta.3`, carrying the removal of
  the `ReceiptTx` class.
- Future `type(scope)!: subject` commits are recognised as breaking, with or without a
  `BREAKING CHANGE:` footer.

## Development related changes

- `@semantic-release/commit-analyzer` and `@semantic-release/release-notes-generator` now receive an
  explicit `parserOpts` with `headerPattern` accepting `!` and a `breakingHeaderPattern`.
- The Release workflow triggers on changes to `.releaserc*`.

Verified against the real commit range with the installed plugin versions: `v11.0.0-beta.2..beta`
goes from `no release` to `major`, and the generated notes list the commit under both `Features` and
`BREAKING CHANGES`. Regression-checked that `feat(x):`, `feat(x)!:` with a footer, `fix(x):` and
merge commits keep their previous release types.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] All tests are passing
